### PR TITLE
Refactor RSpec

### DIFF
--- a/spec/forms/claimant_form_spec.rb
+++ b/spec/forms/claimant_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ClaimantForm, :type => :form do
 
       describe "presence of #{name}" do
         describe "when contact_preference != #{name}" do
-          it { is_expected.to_not validate_presence_of(attribute) }
+          it { is_expected.not_to validate_presence_of(attribute) }
         end
 
         describe "when contact_preference == #{name}" do

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PasswordForm, :type => :form do
   describe 'validations' do
-    it { is_expected.to_not validate_presence_of(:password) }
+    it { is_expected.not_to validate_presence_of(:password) }
     it { is_expected.to     validate_confirmation_of(:password) }
 
     describe 'password_confirmation when password has changed' do
@@ -11,7 +11,7 @@ RSpec.describe PasswordForm, :type => :form do
     end
 
     describe 'password_confirmation when password has not changed' do
-      it { is_expected.to_not validate_presence_of(:password_confirmation) }
+      it { is_expected.not_to validate_presence_of(:password_confirmation) }
     end
   end
   

--- a/spec/forms/respondent_form_spec.rb
+++ b/spec/forms/respondent_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RespondentForm, :type => :form do
       describe "when respondent didn't work at a different address" do
         [:work_address_building, :work_address_street, :work_address_locality,
          :work_address_telephone_number, :work_address_post_code].each do |attr|
-          it { is_expected.to_not validate_presence_of(attr) }
+          it { is_expected.not_to validate_presence_of(attr) }
         end
       end
 
@@ -47,7 +47,7 @@ RSpec.describe RespondentForm, :type => :form do
 
       describe 'when no reason is given for its absence' do
         before { subject.no_acas_number = true }
-        it { is_expected.to_not validate_presence_of(:acas_early_conciliation_certificate_number) }
+        it { is_expected.not_to validate_presence_of(:acas_early_conciliation_certificate_number) }
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe RespondentForm, :type => :form do
       it { is_expected.to ensure_inclusion_of(:no_acas_number_reason).in_array reasons }
 
       describe 'when and ACAS number is given' do
-        it { is_expected.to_not validate_presence_of(:no_acas_number_reason) }
+        it { is_expected.not_to validate_presence_of(:no_acas_number_reason) }
       end
 
       describe 'when and ACAS number is given' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,7 +81,7 @@ RSpec.shared_examples 'a Form' do |attributes, block|
       describe 'for invalid attributes' do
         let(:attributes) { { } }
         it 'is not saved' do
-          expect(resource).to_not receive(:save)
+          expect(resource).not_to receive(:save)
         end
       end
     end


### PR DESCRIPTION
Uses not_to style of expectation, instead of to_not. Reads better.
