### PR TITLE
Remove Claim#to_param

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -11,10 +11,6 @@ class Claim < ActiveRecord::Base
     KeyObfuscator.new.obfuscate(id)
   end
 
-  def to_param
-    reference
-  end
-
   class << self
     def find_by_reference(reference)
       find KeyObfuscator.new.unobfuscate(reference)


### PR DESCRIPTION
No longer needed. We don't show claim ids in the URL anymore.
