### PR TITLE
Rudimentary Claim submission pre-flight sanity check

### DIFF
--- a/app/helpers/claim_reviews_helper.rb
+++ b/app/helpers/claim_reviews_helper.rb
@@ -1,0 +1,7 @@
+module ClaimReviewsHelper
+  def incomplete_claim_warning
+    unless claim.submittable?
+      content_tag(:div, class: 'incomplete-claim') { t 'claim_review.incomplete_claim' }
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,6 +1,9 @@
 class Claim < ActiveRecord::Base
   has_secure_password validations: false
 
+  has_one :primary_claimant,   class_name: 'Claimant'
+  has_one :primary_respondent, class_name: 'Respondent'
+
   has_many :claimants
   has_many :respondents
   has_one  :representative
@@ -33,12 +36,10 @@ class Claim < ActiveRecord::Base
     claimants.where(applying_for_remission: true).count
   end
 
-  def primary_claimant
-    claimants.first
-  end
-
-  def primary_respondent
-    respondents.first
+  def submittable?
+    %i<primary_claimant primary_respondent>.all? do |relation|
+      send(relation).present?
+    end
   end
 
   class << self

--- a/app/views/claim_reviews/show.html.slim
+++ b/app/views/claim_reviews/show.html.slim
@@ -1,9 +1,6 @@
 = content_for(:header) { t 'copy.review.header' }
 
-/ - { :claimant => :primary_claimant, :representative => :representative }.each do |section, object|
-/   - next unless claim.send(object).present?
-/   = render partial: 'review_table',
-/     locals: { presenter: Presenter.for(section).new(claim), section: section }
+= incomplete_claim_warning
 
 - ClaimPresenter::SECTIONS.each do |section|
   - next if presenter.skip? section

--- a/config/locales/claim_review.en.yml
+++ b/config/locales/claim_review.en.yml
@@ -1,5 +1,8 @@
 en:
   claim_review:
+    incomplete_claim: |
+      Your claim is incomplete. Please go back through the form and ensure all
+      required sections are complete
     claimant: Your details
     representative: Your representative
     respondent: Employer's details

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Claim, :type => :model do
 
   it { is_expected.to have_many :claimants }
   it { is_expected.to have_many :respondents }
+  it { is_expected.to have_one  :primary_claimant }
+  it { is_expected.to have_one  :primary_respondent }
 
   let(:claim) { Claim.new id: 1 }
 
@@ -66,6 +68,26 @@ RSpec.describe Claim, :type => :model do
       end
 
       its(:alleges_discrimination_or_unfair_dismissal?) { is_expected.to be true }
+    end
+  end
+
+  describe '#submittable?' do
+    let(:attributes) do
+      {
+        primary_claimant:   Claimant.new,
+        primary_respondent: Respondent.new
+      }
+    end
+
+    context 'when the minimum information is incomplete' do
+      it 'returns false' do
+        expect(attributes.none? { |key, _| Claim.new(attributes.except key).submittable? }).to be true
+      end
+    end
+
+    context 'when the minimum information is complete' do
+      subject { Claim.new attributes }
+      its(:submittable?) { is_expected.to be true }
     end
   end
 end


### PR DESCRIPTION
A better version of this would be to validate against the XSD schema
