### PR TITLE
store office details from fee group reference service

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-FEE_GROUP_REFERENCE_SERVICE_URL=https://etapi.employmenttribunals.service.gov.uk/1/new_claim
+FEE_GROUP_REFERENCE_SERVICE_URL=https://etapi.employmenttribunals.service.gov.uk/1/fgr-office

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-FEE_GROUP_REFERENCE_SERVICE_URL=https://fgr-stub-service.herokuapp.com/1/new_claim
+FEE_GROUP_REFERENCE_SERVICE_URL=https://fgr-stub-service.herokuapp.com/1/fgr-office

--- a/app/jobs/fee_group_reference_job.rb
+++ b/app/jobs/fee_group_reference_job.rb
@@ -4,5 +4,10 @@ class FeeGroupReferenceJob < ActiveJob::Base
   def perform(claim, postcode)
     fee_group_reference = FeeGroupReference.create postcode: postcode
     claim.update! fee_group_reference: fee_group_reference.reference
+    claim.create_office!(
+      code:      fee_group_reference.office_code,
+      name:      fee_group_reference.office_name,
+      address:   fee_group_reference.office_address,
+      telephone: fee_group_reference.office_telephone)
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -8,6 +8,7 @@ class Claim < ActiveRecord::Base
   has_many :respondents, dependent: :destroy
   has_one  :representative, dependent: :destroy
   has_one  :employment, dependent: :destroy
+  has_one  :office, dependent: :destroy
 
   DISCRIMINATION_COMPLAINTS = %i<sex_including_equal_pay disability race age
     pregnancy_or_maternity religion_or_belief sexual_orientation

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,0 +1,3 @@
+class Office < ActiveRecord::Base
+  belongs_to :claim
+end

--- a/app/services/fee_group_reference.rb
+++ b/app/services/fee_group_reference.rb
@@ -1,5 +1,5 @@
 class FeeGroupReference
-  attr_reader :reference
+  attr_reader :reference, :office_code, :office_name, :office_address, :office_telephone
 
   class << self
     def create(postcode:)
@@ -14,6 +14,10 @@ class FeeGroupReference
   def perform
     if request.success?
       @reference = request['fgr']
+      @office_code = request['ETOfficeCode']
+      @office_name = request['ETOfficeName']
+      @office_address = request['ETOfficeAddress']
+      @office_telephone = request['ETOfficeTelephone']
     else
       raise RuntimeError.new "Error #{request['errorCode']}: #{request['errorDescription']}"
     end

--- a/db/migrate/20140901134253_create_office_table.rb
+++ b/db/migrate/20140901134253_create_office_table.rb
@@ -1,0 +1,13 @@
+class CreateOfficeTable < ActiveRecord::Migration
+  def change
+    create_table :offices do |t|
+      t.integer :code
+      t.string :name
+      t.string :address
+      t.string :telephone
+
+      t.timestamps
+      t.references :claim
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140822110044) do
+ActiveRecord::Schema.define(version: 20140901134253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,16 @@ ActiveRecord::Schema.define(version: 20140822110044) do
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "offices", force: true do |t|
+    t.integer  "code"
+    t.string   "name"
+    t.string   "address"
+    t.string   "telephone"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "claim_id"
   end
 
   create_table "representatives", force: true do |t|

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -4,7 +4,7 @@ feature 'Claim applications', type: :feature do
   include FormMethods
 
   before do
-    stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/new_claim').
+    stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/fgr-office').
       with(postcode: 'AT1 4PQ').to_return body: fgr_response.to_json
   end
 

--- a/spec/jobs/fee_group_reference_job_spec.rb
+++ b/spec/jobs/fee_group_reference_job_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe FeeGroupReferenceJob, type: :job do
+  let(:claim) { double }
+  let(:postcode) { 'SW2 2WS' }
+  let(:fee_group_reference) { double reference: 1234567890, office_code: 11, office_name: 'Puddletown', office_address: '1 Some road, Puddletown', office_telephone: '020 1234 5678' }
+
+  before do
+    allow(FeeGroupReference).to receive(:create).with(postcode: postcode).and_return fee_group_reference
+  end
+
+  describe '#perform' do
+    it 'saves fee_group_reference and office details' do
+      expect(claim).to receive(:update!).with(fee_group_reference: 1234567890)
+      expect(claim).to receive(:create_office!).with(code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678')
+
+      subject.perform(claim, postcode)
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Claim, :type => :model do
   it { is_expected.to have_many(:respondents).dependent(:destroy) }
   it { is_expected.to have_one(:representative).dependent(:destroy) }
   it { is_expected.to have_one(:employment).dependent(:destroy) }
+  it { is_expected.to have_one(:office).dependent(:destroy) }
   it { is_expected.to have_one  :primary_claimant }
   it { is_expected.to have_one  :primary_respondent }
 

--- a/spec/services/fee_group_reference_spec.rb
+++ b/spec/services/fee_group_reference_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FeeGroupReference, type: :service do
   describe '.create' do
     let(:request) do
-      stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/new_claim').
+      stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/fgr-office').
         with(postcode: 'SW1A 1AA').to_return body: json,
           headers: { 'Content-Type' => 'application/json' }
     end
@@ -27,8 +27,12 @@ RSpec.describe FeeGroupReference, type: :service do
     context 'when the API request is successful' do
       let(:fgr) { FeeGroupReference.create postcode: 'SW1 1AA' }
 
-      it 'returns an instance exposing the fee group reference' do
+      it 'returns an instance exposing the fee group reference and office details' do
         expect(fgr.reference).to eq(511234567800)
+        expect(fgr.office_code).to eq(22)
+        expect(fgr.office_name).to eq('Birmingham')
+        expect(fgr.office_address).to eq('Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU')
+        expect(fgr.office_telephone).to eq('0121 600 7780')
       end
     end
 


### PR DESCRIPTION
- Update fee group reference job to store office details and store them in a Office model.
- Corrected URL for fee group reference service
