### PR TITLE
highlight missing translations, use relative keys, remove "copy" key, use translations in features

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -1,3 +1,3 @@
 .hidden{
-    display:none;
+    display: none;
 }

--- a/app/forms/claimant_form.rb
+++ b/app/forms/claimant_form.rb
@@ -1,7 +1,7 @@
 class ClaimantForm < Form
   TITLES              = %i<mr mrs ms miss>.freeze
   GENDERS             = %i<male female prefer_not_to_say>.freeze
-  CONTACT_PREFERENCES = %i<email post fax>.freeze
+  CONTACT_PREFERENCES = %w<email post fax>.freeze
   COUNTRIES           = %i<united_kingdom other>.freeze
 
   include AddressAttributes

--- a/app/helpers/claim_reviews_helper.rb
+++ b/app/helpers/claim_reviews_helper.rb
@@ -2,9 +2,13 @@ module ClaimReviewsHelper
   def incomplete_claim_warning
     unless claim.submittable?
       render partial: 'error_header', locals: {
-        summary: t('claim_review.incomplete_claim_summary'),
-        message: t('claim_review.incomplete_claim_message')
+        summary: t('.incomplete_claim_summary'),
+        message: t('.incomplete_claim_message')
       }
     end
+  end
+
+  def review_header
+    I18n.t("#{current_step}.header")
   end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -1,13 +1,9 @@
 module ClaimsHelper
-  def copy_for(key, options = {})
-    Markdown.new(I18n.t 'copy.' + key, options).to_html.html_safe
+  def format(text, options = {})
+    Markdown.new(text, options).to_html.html_safe
   end
 
-  def copy_text
-    t "copy.#{current_step}"
-  end
-
-  def header_text
-    copy_text[:header]
+  def claim_header
+    I18n.t("claims.#{current_step}.header")
   end
 end

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -3,6 +3,6 @@ class BaseMailer < ActionMailer::Base
 
   def access_details_email(claim, email_address)
     @claim = claim
-    mail(to: email_address, subject: t('copy.email.subject', reference: @claim.reference))
+    mail(to: email_address, subject: t('base_mailer.access_details_email.subject', reference: @claim.reference))
   end
 end

--- a/app/presenters/employment_presenter.rb
+++ b/app/presenters/employment_presenter.rb
@@ -56,7 +56,7 @@ class EmploymentPresenter < Presenter
   end
 
   private def period_type(period_type)
-    t "claim_review.employment_pay_period_#{period_type}"
+    t "claim_reviews.show.employment_pay_period_#{period_type}"
   end
 
   private def pay_for(pay)

--- a/app/views/base_mailer/access_details_email.html.slim
+++ b/app/views/base_mailer/access_details_email.html.slim
@@ -3,4 +3,4 @@ html
   head
     meta content='text/html; charset=UTF-8' http-equiv='Content-Type'
   body
-    = copy_for 'email.body', reference: @claim.reference
+    = format t '.body', reference: @claim.reference

--- a/app/views/claim_reviews/show.html.slim
+++ b/app/views/claim_reviews/show.html.slim
@@ -1,16 +1,16 @@
-= content_for(:header, t('copy.review.header'))
+= content_for(:header, t('.header'))
 - content_for(:headeractions) do
   .buttons-action
     button.button Print this page
     button.button Share this page
 - content_for(:info) do
-  p = t('copy.review.info')
+  p = t('.info')
 
 = incomplete_claim_warning
 
 - presenter.each_section do |section|
   table.review-table
-    caption = t "claim_review.#{section}"
+    caption = t ".#{section}"
     colgroup
       col
       col
@@ -18,7 +18,7 @@
     tbody
     - presenter.methods.grep(/\A#{section}_/).each do |method|
       tr
-        th= t "claim_review.#{method}"
+        th= t ".#{method}"
         td= presenter.send(method)
         td
           = link_to "Change", page_claim_path(page: section)

--- a/app/views/claims/_claim.html.slim
+++ b/app/views/claims/_claim.html.slim
@@ -1,8 +1,8 @@
 .main-column
   fieldset.form-panel
-    h2.heading-medium= copy_text[:claim_type]
+    h2.heading-medium= t '.claim_type'
 
-    p.form-hint= copy_text[:claim_type_hint]
+    p.form-hint= t '.claim_type_hint'
 
     = f.input :is_unfair_dismissal,
       as: :gds_check_boxes,

--- a/app/views/claims/_claimant.html.slim
+++ b/app/views/claims/_claimant.html.slim
@@ -1,6 +1,6 @@
 .main-column
   fieldset.form-panel
-    legend.heading-medium= t 'copy.claimant.personal_details'
+    legend.heading-medium= t '.personal_details'
 
     = f.input :title, collection: ClaimantForm::TITLES, include_blank: :translate
     = f.input :first_name
@@ -10,7 +10,7 @@
     = f.input :date_of_birth
 
   fieldset.form-panel
-    legend.heading-medium= t 'copy.claimant.contact_details'
+    legend.heading-medium= t '.contact_details'
 
     = f.input :address_building
     = f.input :address_street

--- a/app/views/claims/_employment.html.slim
+++ b/app/views/claims/_employment.html.slim
@@ -1,7 +1,7 @@
 .main-column
   fieldset
-    legend.visuallyhidden= header_text
-    p= t 'copy.employment.hint'
+    legend.visuallyhidden= t '.header'
+    p= t '.hint'
 
     = f.input :job_title
 

--- a/app/views/claims/_password.html.slim
+++ b/app/views/claims/_password.html.slim
@@ -1,17 +1,16 @@
 section
   .main-column
-    p= copy_for 'password.info'
+    p= format t '.info'
 
-
-    h2.heading-medium= t 'copy.password.access_details.header'
+    h2.heading-medium= t '.access_details.header'
 
     p.strong
-      = t 'copy.password.access_details.reference'
+      = t '.access_details.reference'
     p.reference= claim.reference
 
     p= f.input :password, as: :string
 
-    h2.heading-medium= t 'copy.password.record_details.header'
-    p= t 'copy.password.record_details.info'
+    h2.heading-medium= t '.record_details.header'
+    p= t '.record_details.info'
 
     p= f.input :save_and_return_email

--- a/app/views/claims/_representative.html.slim
+++ b/app/views/claims/_representative.html.slim
@@ -1,6 +1,6 @@
 .main-column
   fieldset.form-panel
-    legend.visuallyhidden= header_text
+    legend.visuallyhidden= t '.header'
     = f.input :type, collection: RepresentativeForm::TYPES, include_blank: :translate
     = f.input :organisation_name
     = f.input :name

--- a/app/views/claims/_respondent.slim
+++ b/app/views/claims/_respondent.slim
@@ -1,7 +1,7 @@
 .main-column
   fieldset.form-panel
-    legend.visuallyhidden= header_text
-    p= t 'copy.respondent.hint'
+    legend.visuallyhidden= t '.header'
+    p= t '.hint'
 
     = f.input :name
 
@@ -19,7 +19,7 @@
       reveal: { true => :work_address_wrapper }
 
     #work_address_wrapper.panel-indent.toggle-content.work-address
-      p.form-hint= t 'copy.respondent.work_address'
+      p.form-hint= t '.work_address'
 
       = f.input :work_address_building
       = f.input :work_address_street

--- a/app/views/claims/new.html.slim
+++ b/app/views/claims/new.html.slim
@@ -1,6 +1,6 @@
-= content_for(:header, t('copy.new.header'))
+= content_for(:header, t('.header'))
 - content_for(:info) do
-  p = t('copy.new.info')
+  p = t '.info'
 
 section
   .main-column
@@ -8,4 +8,4 @@ section
       = f.button :submit
     = link_to t('helpers.link.claim.return'), new_user_sessions_path
 
-    .content-copy = copy_for 'new.body'
+    .content-copy = format t '.body'

--- a/app/views/claims/show.html.slim
+++ b/app/views/claims/show.html.slim
@@ -1,4 +1,4 @@
-= content_for(:header) { header_text }
+= content_for(:header, claim_header)
 
 section
   = simple_form_for resource, url: claim_path do |f|

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,5 +1,5 @@
-= content_for(:header, t('copy.user_session.new.header'))
-= content_for(:info, t('copy.user_session.info'))
+= content_for(:header, t('.header'))
+= content_for(:info, t('.info'))
 
 section
   .main-column

--- a/app/views/user_sessions/show.html.slim
+++ b/app/views/user_sessions/show.html.slim
@@ -1,12 +1,12 @@
-= content_for(:header, t('copy.user_session.show.header'))
+= content_for(:header, t('.header'))
 
 section
   .main-column
-    p= copy_for 'user_session.show.info'
+    p= format t '.info'
 
     = simple_form_for user_session, url: user_sessions_path, method: :delete do |f|
       p.reference
-        = t 'copy.password.access_details.reference'
+        = t 'claims.password.access_details.reference'
       p.reference
         strong= claim.reference
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   #Rack livereload for frontend development
   config.middleware.use Rack::LiveReload

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,5 +35,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/locales/claim_review.en.yml
+++ b/config/locales/claim_review.en.yml
@@ -1,66 +1,73 @@
 en:
   presenters:
     blank: Not entered
-  claim_review:
-    incomplete_claim_summary: |
-      Your claim is incomplete.
-    incomplete_claim_message: |
-      Please go back through the form and ensure all required sections are complete
-    claimant: Your details
-    representative: Your representative
-    respondent: Employer's details
+  claim_reviews:
+    show:
+      header: Check your details
+      info: |
+        You can change anything that's not right before sending your application.
+      incomplete_claim_summary: |
+        Your claim is incomplete.
+      incomplete_claim_message: |
+        Please go back through the form and ensure all required sections are complete
 
-    claimant_full_name: Full name
-    claimant_gender: Gender
-    claimant_date_of_birth: Date of birth
-    claimant_address: Address
-    claimant_telephone_number: Telephone
-    claimant_mobile_number: Mobile
-    claimant_contact_preference: Preferred contact
-    claimant_is_disabled: Disability
-    claimant_is_applying_for_remission: Fee remission
-    claimant_has_representative: Representative
+      claimant: Your details
+      representative: Your representative
+      respondent: Employer's details
+      claim_detail: Claim details
+      employment: Employment details
 
-    representative_type: Type of representative
-    representative_organisation_name: Organisation name
-    representative_name: Full name
-    representative_address: Address
-    representative_telephone_number: Telephone
-    representative_mobile_number: Mobile
-    representative_email_address: Email
-    representative_dx_number: DX number
-    representative_contact_preference: Preferred contact
+      claimant_full_name: Full name
+      claimant_gender: Gender
+      claimant_date_of_birth: Date of birth
+      claimant_address: Address
+      claimant_telephone_number: Telephone
+      claimant_mobile_number: Mobile
+      claimant_contact_preference: Preferred contact
+      claimant_is_disabled: Disability
+      claimant_is_applying_for_remission: Fee remission
+      claimant_has_representative: Representative
 
-    respondent_name: Name
-    respondent_address: Address
-    respondent_telephone_number: Telephone
-    respondent_employed_by_employer: Employed by employer
-    respondent_acas_early_conciliation_certificate_number: Acas number
-    respondent_no_acas_number_reason: Reason for no Acas number
+      representative_type: Type of representative
+      representative_organisation_name: Organisation name
+      representative_name: Full name
+      representative_address: Address
+      representative_telephone_number: Telephone
+      representative_mobile_number: Mobile
+      representative_email_address: Email
+      representative_dx_number: DX number
+      representative_contact_preference: Preferred contact
 
-    employment_job_title: Job
-    employment_start_date: Start date
-    employment_average_hours_worked_per_week: Average hours worked
-    employment_gross_pay: Pay before tax
-    employment_net_pay: Pay after tax
-    employment_enrolled_in_pension_scheme: Pension scheme
-    employment_benefit_details: Benefit details
-    employment_current_situation: Current situation
-    employment_end_date: End date
-    employment_worked_notice_period_or_paid_in_lieu: Notice period
-    employment_notice_period_end_date: Notice period end date
-    employment_notice_period_pay: Notice pay
-    employment_new_job: Another job
-    employment_new_job_gross_pay: Pay before tax at new job
+      respondent_name: Name
+      respondent_address: Address
+      respondent_telephone_number: Telephone
+      respondent_employed_by_employer: Employed by employer
+      respondent_acas_early_conciliation_certificate_number: Acas number
+      respondent_no_acas_number_reason: Reason for no Acas number
 
-    employment_pay_period_weekly: per week
-    employment_pay_period_monthly: per month
+      employment_job_title: Job
+      employment_start_date: Start date
+      employment_average_hours_worked_per_week: Average hours worked
+      employment_gross_pay: Pay before tax
+      employment_net_pay: Pay after tax
+      employment_enrolled_in_pension_scheme: Pension scheme
+      employment_benefit_details: Benefit details
+      employment_current_situation: Current situation
+      employment_end_date: End date
+      employment_worked_notice_period_or_paid_in_lieu: Notice period
+      employment_notice_period_end_date: Notice period end date
+      employment_notice_period_pay: Notice pay
+      employment_new_job: Another job
+      employment_new_job_gross_pay: Pay before tax at new job
 
-    claim_detail_types: Type(s)
-    claim_detail_claim_details: Claim details
-    claim_detail_desired_outcomes: What outcome?
-    claim_detail_other_outcome: Outcome description
-    claim_detail_other_known_claimant_names: Other known claimants
-    claim_detail_is_whistleblowing: Whistleblowing
-    claim_detail_send_claim_to_whistleblowing_entity: Send to whistleblowing body
-    claim_detail_miscellaneous_information: Other information
+      employment_pay_period_weekly: per week
+      employment_pay_period_monthly: per month
+
+      claim_detail_types: Type(s)
+      claim_detail_claim_details: Claim details
+      claim_detail_desired_outcomes: What outcome?
+      claim_detail_other_outcome: Outcome description
+      claim_detail_other_known_claimant_names: Other known claimants
+      claim_detail_is_whistleblowing: Whistleblowing
+      claim_detail_send_claim_to_whistleblowing_entity: Send to whistleblowing body
+      claim_detail_miscellaneous_information: Other information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,16 +254,15 @@ en:
       not_found: A claim with that 'save and return' number could not be found
       invalid: This memorable word does not match the 'save and return' number
 
-  copy:
-    user_session:
-      new:
-        header: Return to your saved form
-        info: Sign in to return to your saved form.
-        body: If you don't have your 'save and return' number and memorable word you'll have to [start a new form](/).
-      show:
-        header: Saved
-        info: Make sure you know your  'save and return’ number and memorable word before you sign out (or you'll lose your work).
-
+  user_sessions:
+    new:
+      header: Return to your saved form
+      info: Sign in to return to your saved form.
+      body: If you don't have your 'save and return' number and memorable word you'll have to [start a new form](/).
+    show:
+      header: Saved
+      info: Make sure you know your  'save and return’ number and memorable word before you sign out (or you'll lose your work).
+  claims:
     new:
       header: Take your employer to a tribunal
       info: Apply online to an employment tribunal with an ET1 claim form (England, Wales and Scotland).
@@ -314,20 +313,6 @@ en:
         header: What is your email address?
         info: Your ‘save and return’ number will be emailed to this address
 
-    email:
-      subject: 'Employment tribunal: %{reference}'
-      body: |
-        Thank you for starting an employment tribunal claim form.
-
-        Your unique 'save and return' number is:
-
-        __%{reference}__
-
-        You need this number, and your memorable word, to [return to your form](http://gov.uk/) (if you don't complete it in one session).
-
-      reference:
-        header: "'Save and return' number"
-
     claimant:
       header: Your details
       personal_details: Personal details
@@ -353,7 +338,18 @@ en:
       header: Claim details
       claim_type: What type of claim - or claims - are you making?
       claim_type_hint: You can select more than one
-    review:
-      header: Check your details
-      info: |
-        You can change anything that's not right before sending your application.
+
+  base_mailer:
+    access_details_email:
+      subject: 'Employment tribunal: %{reference}'
+      body: |
+        Thank you for starting an employment tribunal claim form.
+
+        Your unique 'save and return' number is:
+
+        __%{reference}__
+
+        You need this number, and your memorable word, to [return to your form](http://gov.uk/) (if you don't complete it in one session).
+
+    reference:
+      header: "'Save and return' number"

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Claim applications', type: :feature do
   include FormMethods
+  include Messages
 
   before do
     stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/fgr-office').
@@ -20,7 +21,7 @@ feature 'Claim applications', type: :feature do
 
   scenario 'Create a new application' do
     start_claim
-    expect(page).to have_text('Before you start')
+    expect(page).to have_text(claim_heading_for(:password))
   end
 
   scenario 'Entering word for save and return' do
@@ -31,7 +32,7 @@ feature 'Claim applications', type: :feature do
     claim = Claim.first
     expect(claim.authenticate 'green').to eq(claim)
 
-    expect(page).to have_text('Your details')
+    expect(page).to have_text(claim_heading_for(:claimant))
     expect(page).to have_button('Complete later')
   end
 
@@ -45,7 +46,7 @@ feature 'Claim applications', type: :feature do
     mail = ActionMailer::Base.deliveries.last
     expect(mail.subject).to include(claim.reference)
 
-    expect(page).to have_text('Your details')
+    expect(page).to have_text(claim_heading_for(:claimant))
   end
 
   scenario 'Entering personal details' do
@@ -53,7 +54,7 @@ feature 'Claim applications', type: :feature do
     fill_in_password
     fill_in_personal_details
 
-    expect(page).to have_text("Your representative")
+    expect(page).to have_text(claim_heading_for(:representative))
   end
 
   scenario 'Entering representative details' do
@@ -62,7 +63,7 @@ feature 'Claim applications', type: :feature do
     fill_in_personal_details
     fill_in_representative_details
 
-    expect(page).to have_text("Employer's details")
+    expect(page).to have_text(claim_heading_for(:respondent))
   end
 
   scenario 'Entering employer details' do
@@ -72,7 +73,7 @@ feature 'Claim applications', type: :feature do
     fill_in_representative_details
     fill_in_employer_details
 
-    expect(page).to have_text("Employment details")
+    expect(page).to have_text(claim_heading_for(:employment))
   end
 
   scenario 'Entering employment details' do
@@ -83,7 +84,7 @@ feature 'Claim applications', type: :feature do
     fill_in_employer_details
     fill_in_employment_details
 
-    expect(page).to have_text("Claim details")
+    expect(page).to have_text(claim_heading_for(:claim))
   end
 
   scenario 'Entering claim details' do
@@ -95,6 +96,6 @@ feature 'Claim applications', type: :feature do
     fill_in_employment_details
     fill_in_claim_details
 
-    expect(page).to have_text('Check your details')
+    expect(page).to have_text(review_heading_for(:show))
   end
 end

--- a/spec/features/save_and_return_spec.rb
+++ b/spec/features/save_and_return_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Save and Return' do
   include FormMethods
+  include Messages
 
   scenario 'ending the session' do
     start_claim
@@ -13,7 +14,7 @@ feature 'Save and Return' do
     expect(page).to have_text(Claim.last.reference)
     click_button 'Sign out now'
 
-    expect(page).to have_text('Take your employer to a tribunal')
+    expect(page).to have_text(claim_heading_for(:new))
   end
 
   scenario 'ending the session when current page invalid' do
@@ -30,7 +31,7 @@ feature 'Save and Return' do
     end_session
     fill_in_return_form Claim.last.reference, 'green'
 
-    expect(page).to have_text('Your details')
+    expect(page).to have_text(claim_heading_for(:claimant))
     expect(page).to have_field('Last name', with: 'Wrigglesworth')
   end
 end

--- a/spec/support/messages.rb
+++ b/spec/support/messages.rb
@@ -1,0 +1,9 @@
+module Messages
+  def claim_heading_for(page)
+    I18n.t("claims.#{page}.header")
+  end
+
+  def review_heading_for(page)
+    I18n.t("claim_reviews.#{page}.header")
+  end
+end


### PR DESCRIPTION
- Raise exceptions in dev and test when translations are missing
- use relative translation keys where possible (moved some keys around to 
  facilitate this including removal of 'copy' key)
- move some keys for claim_reviews into `claim_review.en.yml`
- start to use translation helpers in features 

Frigged about trying to log exceptions in production but couldn't get this to work:
http://guides.rubyonrails.org/i18n.html#using-different-exception-handlers

So raising is just done in dev and test for now. Should cover most cases.
