### PR TITLE
PaymentGateway dev fix

### DIFF
--- a/app/services/payment_gateway.rb
+++ b/app/services/payment_gateway.rb
@@ -1,5 +1,10 @@
 module PaymentGateway
-  @available = nil
+  # Assume payment gateway is up until we find it isn't. Because classes are
+  # reloaded every request in development, it creates a race condition where
+  # PaymentGateway.available? may be nil in the request. Because classes are
+  # cached in test and also eager loaded in production this shouldn't be a problem
+  # in those environments, but it's annoying in development
+  @available = true
   MUTEX = Mutex.new
 
   TASK = PeriodicTask.new(every: 5.seconds, run_immediately: !Rails.env.test?) do

--- a/app/validators/post_code_validator.rb
+++ b/app/validators/post_code_validator.rb
@@ -1,10 +1,10 @@
 class PostCodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value
+    if value.present?
       postcode = UKPostcode.new(value)
       message  = options[:message] || I18n.t('errors.messages.invalid')
 
-      record.errors[attribute] << message unless value.blank? || (postcode.valid? && postcode.full?)
+      record.errors[attribute] << message unless postcode.valid? && postcode.full?
     end
   end
 end


### PR DESCRIPTION
Assume payment gateway is up until we find it isn't. Because classes are
reloaded every request in development, it creates a race condition where
PaymentGateway.available? may be nil in the request. Because classes are
cached in test and also eager loaded in production this shouldn't be a problem
in those environments, but it's annoying in development
