### PR TITLE
fix a couple of deprecations

### DIFF
--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -15,7 +15,7 @@ class PasswordForm < Form
 
   def deliver_access_details
     if save_and_return_email.present?
-      BaseMailer.access_details_email(resource, save_and_return_email).deliver
+      BaseMailer.access_details_email(resource, save_and_return_email).deliver_later
     else
       true
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,9 @@ module App
     config.product_type = ''
     # Feedback URL (URL for feedback link in phase banner)
     config.feedback_url = ''
+
+    # opt into features that will be the default in the next version of Rails
+    # (and supress the DEPRECATION warnings)
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PasswordForm, :type => :form do
       it "sends an email" do
         subject.save_and_return_email = email_address
         mock_mailer = double(:mailer)
-        expect(mock_mailer).to receive(:deliver)
+        expect(mock_mailer).to receive(:deliver_later)
         expect(BaseMailer).to receive(:access_details_email).with(model, email_address).and_return(mock_mailer)
         subject.deliver_access_details
       end


### PR DESCRIPTION
- raise in transactional callbacks (currently suppressed and logged)
- `deliver` used when sending save and return email (switched to `deliver_later`)
