### PR TITLE
Fix/Add correspondence translation on claimant form

### DIFF
--- a/config/initializers/form_options.rb
+++ b/config/initializers/form_options.rb
@@ -1,7 +1,7 @@
 module FormOptions
   TITLES              = %i<mr mrs ms miss>.freeze
   GENDERS             = %i<male female prefer_not_to_say>.freeze
-  CONTACT_PREFERENCES = %w<email post fax>.freeze
+  CONTACT_PREFERENCES = %i<email post fax>.freeze
   COUNTRIES           = %i<united_kingdom other>.freeze
   NO_ACAS_REASON = %i<
     joint_claimant_has_acas_number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
           male: Male
           female: Female
           prefer_not_to_say: Prefer not to say
+        contact_preferences:
+          email: Email
+          post: Post
+          fax: Fax
         title:
           mr: Mr
           mrs: Mrs


### PR DESCRIPTION
Use symbols for contact preferences in FormOptions so SimpleForm can translate correctly.
