### PR TITLE
Add Google Analytics tracking codez

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,18 @@
 - content_for :javascripts do
   = javascript_include_tag "application"
 
+  - if ENV.has_key?('GOOGLE_ANALYTICS_ID')
+    javascript:
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '#{ENV.fetch("GOOGLE_ANALYTICS_ID")}', 'auto');
+      ga('send', 'pageview');
+      ga('set', 'anonymizeIP', true);
+
+
 - content_for :body_classes, "#{config_item(:phase).to_s.downcase} #{config_item(:product_type).to_s.downcase} #{controller.controller_name} #{controller.action_name}"
 
 - content_for :after_header do


### PR DESCRIPTION
Needs GOOGLE_ANALYTICS_ID set in ENV or GA code will not be rendered
into the view.

@paulrhodes please set `GOOGLE_ANALYTICS_ID` to `UA-41756109-3` in the trial env.
