### PR TITLE
invert worked at different address logic to match copy

### DIFF
--- a/app/forms/respondent_form.rb
+++ b/app/forms/respondent_form.rb
@@ -7,14 +7,14 @@ class RespondentForm < Form
              :work_address_county, :work_address_post_code,
              :work_address_telephone_number,
              :acas_early_conciliation_certificate_number,
-             :no_acas_number_reason, :worked_at_different_address
+             :no_acas_number_reason, :worked_at_same_address
 
   booleans   :no_acas_number
 
   validates :name, presence: true
 
   validates :work_address_street, :work_address_locality, :work_address_building,
-            :work_address_post_code, presence: { if: -> { worked_at_different_address } }
+            :work_address_post_code, presence: { unless: -> { worked_at_same_address } }
 
   validates :name, length: { maximum: NAME_LENGTH }
   validates :work_address_building,

--- a/app/views/claims/_respondent.slim
+++ b/app/views/claims/_respondent.slim
@@ -30,7 +30,7 @@
 
     fieldset.form-panel
       legend= t '.workaddress_legend'
-      = f.input :worked_at_different_address,
+      = f.input :worked_at_same_address,
         as: :radio_buttons,
         item_wrapper_class: 'block-label',
         wrapper_html: { class: 'form-group-reveal' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,7 +172,7 @@ en:
         work_address_street: Street
         work_address_county: County
         work_address_post_code: Postcode
-        worked_at_different_address: Did you work at the same address to the one given above?
+        worked_at_same_address: Did you work at the same address to the one given above?
         no_acas_number: I don't have an Acas number
         no_acas_number_reason: Why don't you have an Acas number?
 

--- a/db/migrate/20141014081047_rename_worked_at_different_address.rb
+++ b/db/migrate/20141014081047_rename_worked_at_different_address.rb
@@ -1,0 +1,6 @@
+class RenameWorkedAtDifferentAddress < ActiveRecord::Migration
+  def change
+    rename_column :respondents, :worked_at_different_address, :worked_at_same_address
+    change_column :respondents, :worked_at_same_address, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141013135208) do
+ActiveRecord::Schema.define(version: 20141014081047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 20141013135208) do
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "worked_at_different_address",                            default: false
+    t.boolean  "worked_at_same_address",                                 default: true
     t.boolean  "primary_respondent",                                     default: false
   end
 

--- a/spec/forms/respondent_form_spec.rb
+++ b/spec/forms/respondent_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RespondentForm, :type => :form do
       end
 
       describe "when respondent worked at a different address" do
-        before { subject.worked_at_different_address = true }
+        before { subject.worked_at_same_address = false }
         [:work_address_building, :work_address_street, :work_address_locality,
          :work_address_post_code].each do |attr|
           it { is_expected.to validate_presence_of(attr) }
@@ -84,7 +84,7 @@ RSpec.describe RespondentForm, :type => :form do
     work_address_building: "2", work_address_street: "Business Lane",
     work_address_locality: "Business City", work_address_county: 'Businessbury',
     work_address_post_code: "SW1A 1AA", work_address_telephone_number: "01234000000",
-    worked_at_different_address: true, no_acas_number: "1",
+    worked_at_same_address: false, no_acas_number: "1",
     no_acas_number_reason: "acas_has_no_jurisdiction" }
 
   before = proc do

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -89,7 +89,7 @@ module FormMethods
     fill_in :respondent_address_post_code,        with: 'AT3 0AS'
     fill_in :respondent_address_telephone_number, with: '01234567890'
 
-    choose 'respondent_worked_at_different_address_false'
+    choose 'respondent_worked_at_same_address_false'
 
     within('.work-address') { fill_in_address }
 


### PR DESCRIPTION
Couldn't see why the overridden method `worked_at_different_address=` exists. I've tested various different cases without it and everything seems to work. I also noticed it's not included as a boolean as `no_acas_number` is but again everything seems to work but maybe I'm missing something.
