### PR TITLE
fix worked_at_different_address logic

### DIFF
--- a/app/forms/respondent_form.rb
+++ b/app/forms/respondent_form.rb
@@ -45,9 +45,4 @@ class RespondentForm < Form
   private def target
     resource.primary_respondent || resource.build_primary_respondent
   end
-
-  def worked_at_different_address=(v)
-    type = ActiveRecord::Type::Boolean.new
-    attributes[:worked_at_different_address] = type.type_cast_from_user(v)
-  end
 end

--- a/app/views/claims/_respondent.slim
+++ b/app/views/claims/_respondent.slim
@@ -34,7 +34,7 @@
         as: :radio_buttons,
         item_wrapper_class: 'block-label',
         wrapper_html: { class: 'form-group-reveal' },
-        reveal: { true => :work_address_wrapper }
+        reveal: { false => :work_address_wrapper }
 
       #work_address_wrapper.panel-indent.toggle-content.work-address
         p.form-hint= t '.work_address'

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -89,7 +89,7 @@ module FormMethods
     fill_in :respondent_address_post_code,        with: 'AT3 0AS'
     fill_in :respondent_address_telephone_number, with: '01234567890'
 
-    choose 'respondent_worked_at_different_address_true'
+    choose 'respondent_worked_at_different_address_false'
 
     within('.work-address') { fill_in_address }
 


### PR DESCRIPTION
To me, this is not very intention revealing. Should I perhaps add a method that wraps in the inverted logic or am I missing a simple addition that makes this change make sense?

Note that currently it won't reveal the extra fields on page load but David is working on a fix for that.
