### PR TITLE
DRY up sidebar "Get help" and make structure consistent across pages

### DIFF
--- a/app/views/base_mailer/confirmation_email.html.slim
+++ b/app/views/base_mailer/confirmation_email.html.slim
@@ -3,4 +3,9 @@ html
   head
     meta content='text/html; charset=UTF-8' http-equiv='Content-Type'
   body
-    = render partial: '/claim_reviews/confirmation'
+    header.main-header
+      h1= t 'claim_reviews.confirmation.header'
+
+    .main-section
+      .main-content
+        = render partial: '/claim_reviews/confirmation'

--- a/app/views/claim_confirmations/show.html.slim
+++ b/app/views/claim_confirmations/show.html.slim
@@ -1,1 +1,8 @@
-= render partial: '/claim_reviews/confirmation'
+header.main-header
+  h1= t 'claim_reviews.confirmation.header'
+
+.main-section
+  = render partial: 'shared/aside'
+
+  .main-content
+    = render partial: '/claim_reviews/confirmation'

--- a/app/views/claim_reviews/_confirmation.html.slim
+++ b/app/views/claim_reviews/_confirmation.html.slim
@@ -1,12 +1,13 @@
-section= format t('.complete', reference: @claim.reference)
+section= t('.complete', reference: @claim.reference)
 section= format t('.fee_paid') if @claim.payment_present?
 section= format t('.remission_help') if @claim.remission_applicable?
 section
   h2= t('.details.header')
   table
-    tr
-      td= t('.details.date_submitted')
-      td= @claim.submitted_at
+    - if @claim.submitted_at.present?
+      tr
+        td= t('.details.date_submitted')
+        td= @claim.submitted_at
     - if @claim.payment_present?
       tr
         td= t('.details.fee_paid')

--- a/app/views/claim_reviews/show.html.slim
+++ b/app/views/claim_reviews/show.html.slim
@@ -3,26 +3,24 @@ header.main-header
   h1= t('.header')
   p = t('.info')
 
-- content_for(:headeractions) do
-  .buttons-action
-    button.button Print this page
-    button.button Share this page
+.main-section
+  = render partial: 'shared/aside'
 
-= incomplete_claim_warning
+  .main-content
+    = incomplete_claim_warning
+    - presenter.each_section do |section|
+      table.review-table
+        caption = t ".#{section}"
+        colgroup
+          col
+          col
+          col
+        tbody
+        - presenter.methods.grep(/\A#{section}_/).each do |method|
+          tr
+            th= t ".#{method}"
+            td= presenter.send(method)
+            td
+              = link_to t('.change'), page_claim_path(page: section)
 
-- presenter.each_section do |section|
-  table.review-table
-    caption = t ".#{section}"
-    colgroup
-      col
-      col
-      col
-    tbody
-    - presenter.methods.grep(/\A#{section}_/).each do |method|
-      tr
-        th= t ".#{method}"
-        td= presenter.send(method)
-        td
-          = link_to t('.change'), page_claim_path(page: section)
-
-= render partial: 'email_addresses'
+    = render partial: 'email_addresses'

--- a/app/views/claims/new.html.slim
+++ b/app/views/claims/new.html.slim
@@ -3,14 +3,8 @@ header.main-header.no-steps
   p= t('.info')
 
 .main-section
-  aside
-    h3 Get Help
-    nav
-      ul
-        li
-          = link_to('Read the guide', guide_path)
-        li
-          = link_to('Sign out', user_session_path)
+  = render partial: 'shared/aside', locals: {hide: [:signout]}
+
   .main-content
     = simple_form_for claim, url: claim_path do |f|
       fieldset

--- a/app/views/claims/show.html.slim
+++ b/app/views/claims/show.html.slim
@@ -3,14 +3,8 @@ header.main-header
   h1= claim_header
 
 .main-section
-  aside
-    h3 Get Help
-    nav
-      ul
-        li
-          = link_to('Read the guide', guide_path)
-        li
-          = link_to('Sign out', user_session_path)
+  = render partial: 'shared/aside'
+  
   .main-content
     = simple_form_for resource, url: claim_path, multipart: true do |f|
       = hidden_field_tag :page, current_step

--- a/app/views/guides/show.html.slim
+++ b/app/views/guides/show.html.slim
@@ -1,13 +1,12 @@
-.main-content 
-  fieldset.form-panel
+header.main-header
+  h1= t '.header'
 
-  h1= t("guide.header")
-
+.main-content
   - cache do
     nav.nav-guide
       ul
       - @guide_presenter.file_names.each do |name|
-        li = link_to t("guide.#{name}"), guide_path(anchor: name)
+        li = link_to t(".#{name}"), guide_path(anchor: name)
 
     .guide-content
       - @guide_presenter.each_rendered_file do |name, contents|

--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -1,0 +1,9 @@
+- hide ||= []
+aside
+  h3= t '.gethelp'
+  nav
+    ul
+      li= link_to t('.read_guide'), guide_path
+      li= link_to t('.contact_us'), t('.contact_us_link')
+      - unless hide.include?(:signout)
+        li= link_to t('.signout'), user_session_path

--- a/app/views/user_sessions/edit.html.slim
+++ b/app/views/user_sessions/edit.html.slim
@@ -2,14 +2,8 @@ header.main-header.no-steps
   h1= t('.header')
 
 .main-section
-  aside
-    h3 Get Help
-    nav
-      ul
-        li
-          = link_to('Read the guide', guide_path)
-        li
-          = link_to('Sign out', user_session_path)
+  = render partial: 'shared/aside', locals: {hide: [:signout]}
+
   .main-content
     .main-column
 

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -2,6 +2,8 @@ header.main-header
   h1= t('.header')
 
 .main-section
+  = render partial: 'shared/aside'
+  
   .main-content
     .main-column
       = simple_form_for user_session, url: user_session_path do |f|

--- a/app/views/user_sessions/show.html.slim
+++ b/app/views/user_sessions/show.html.slim
@@ -2,6 +2,8 @@ header.main-header
   h1= t('.header')
 
 .main-section
+  = render partial: 'shared/aside'
+
   .main-content
     .main-column
       .callout.callout-reference

--- a/config/locales/claim_review.en.yml
+++ b/config/locales/claim_review.en.yml
@@ -80,10 +80,8 @@ en:
       add_email_address: Add email address
 
     confirmation:
-      complete: |
-        # Application complete
-
-        Your application reference number: %{reference}
+      header: Application complete
+      complete: 'Your application number: %{reference}'
 
       fee_paid: |
         ## Thank you for your payment. We’ll write to you within 5 working days.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,7 +122,7 @@ en:
     labels:
       user_session:
         new:
-          reference: Your reference number
+          reference: Your application number
           password: Your memorable word
         edit:
           password: Enter a memorable word (at least 5 characters)
@@ -319,15 +319,23 @@ en:
       claim:
         return: Return to your saved form
 
+  shared:
+    aside:
+      gethelp: Get help
+      read_guide: Read the guide
+      contact_us: Contact us
+      contact_us_link: http://www.justice.gov.uk/contacts/hmcts/tribunals/employment
+      signout: Sign out and complete later
+
   errors:
     messages:
       rtf: is not an RTF or plain text file
     user_session:
-      not_found: A claim with that reference number could not be found
-      invalid: This memorable word does not match the reference number
+      not_found: A claim with that application number could not be found
+      invalid: This memorable word does not match the application number
 
   user_sessions:
-    reference: Your reference number is
+    reference: Your application number is
     edit:
       header: Before you start
       memorable_word_legend: Returning to your application
@@ -348,12 +356,13 @@ en:
       subheader: Keep a note of these details
       hint: You need this number to save your work and return to it another time
 
-  guide:
-    header: Guide
-    fees: Fees
-    acas_early_conciliation: |
-      Acas: early conciliation
-    writing_your_claim_statement: Writing your claim statement
+  guides:
+    show:
+      header: Guide
+      fees: Fees
+      acas_early_conciliation: |
+        Acas: early conciliation
+      writing_your_claim_statement: Writing your claim statement
 
   claims:
     new:
@@ -361,7 +370,7 @@ en:
       info: Apply online to an employment tribunal
       body: |
         ## Before you start
-        
+
         You'll need:
 
         * your Acas early conciliation certificate number
@@ -381,7 +390,7 @@ en:
 
       access_details:
         header: Keep a note of these details
-        reference: Your reference number
+        reference: Your application number
         hint: You need this number to save your work and return to it another time
 
       record_details:
@@ -477,7 +486,7 @@ en:
       body: |
         Thank you for starting an employment tribunal claim form.
 
-        Your reference number is:
+        Your application number is:
 
         __%{reference}__
 
@@ -488,7 +497,7 @@ en:
       subject: Employment tribunal submitted
 
     reference:
-      header: Reference number
+      header: Application number
 
   # Form Errors - Handled by ActiveModel
   activemodel:

--- a/spec/services/payment_gateway/response_spec.rb
+++ b/spec/services/payment_gateway/response_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe PaymentGateway::Response, type: :service do
   describe '#valid?' do
     context 'with a valid signature' do
       it 'returns true' do
-        # binding.pry
         expect(subject.valid?).to be true
       end
     end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -15,7 +15,7 @@ module FormMethods
 
   def fill_in_return_form reference, word
     visit '/user_session/new'
-    fill_in 'reference', with: reference
+    fill_in 'application number', with: reference
     fill_in 'memorable word', with: word
     click_button 'Find my application'
   end

--- a/spec/support/messages.rb
+++ b/spec/support/messages.rb
@@ -14,7 +14,7 @@ module Messages
   end
 
   def completion_message(reference)
-    format I18n.t('claim_reviews.confirmation.complete', reference: reference)
+    I18n.t('claim_reviews.confirmation.complete', reference: reference)
   end
 
   def payment_message


### PR DESCRIPTION
Also:
- fixed up some copy changes (e.g. reference number -> application number)
- hid submitted_at row on confirmation page if no date (e.g. when manually submitting)
