### PR TITLE
Various Text Changes

### DIFF
--- a/app/views/claims/new.html.slim
+++ b/app/views/claims/new.html.slim
@@ -11,11 +11,11 @@ header.main-header.no-steps
         legend Before you continue
         .content-copy
           .content-block
-            h3 Are you in time to apply?
-            p You usually have to apply to the tribunal within 3 months of your employment ending or the problem happening. Learn about when you can apply.
+            h3 = t('.are_you_in_time_to_apply.header')
+            p = format t('.are_you_in_time_to_apply.body')
           .content-block
-            h3 Have you contacted ACAS?
-            p In most cases, you need to contact Acas for conciliation before the tribunal can consider your application.
+            h3 = t('.have_you_contacted_acas.header')
+            p = format t('.have_you_contacted_acas.body')
 
         .inline.inline-buttons
           = f.button :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,7 +268,7 @@ en:
           Eg, you may want to tell us why your claim is late, or whether you've spoken to your employer about the problem at work
       respondent:
         acas_early_conciliation_certificate_number: |
-          Nearly everyone should have this number before they fill in a claim form. You can find it on your Acas certificate. For help and advice, call Acas on 0300 123 1100 or visit the Acas website.
+          Nearly everyone should have this number before they fill in a claim form. You can find it on your Acas certificate. For help and advice, call Acas on 0300 123 1100 or <a href="http://www.acas.org.uk/earlyconciliation">visit the Acas website</a>.
         address_building: |
           May be different to your work address
       claim_type:
@@ -279,7 +279,7 @@ en:
         is_whistleblowing: |
           You can report things at work that aren’t right, are illegal or if anyone is neglecting their duties.
       claim_details:
-        claim_details: Include the background, dates and the people involved. Limit is 5000 characters.
+        claim_details: Include the background, dates and the people involved. <a href="/guide#writing_your_claim_statement">What else do I need to include?</a> Limit is 5000 characters.
         other_known_claimants: |
           A judge may combine similar claims to manage and hear them together. This may save you and the tribunal time and money.
         other_known_claimant_names: Limit is 350 characters.
@@ -366,10 +366,18 @@ en:
     new:
       header: Start your application
       info: Apply online to an employment tribunal
+      are_you_in_time_to_apply:
+        header: Are you in time to apply?
+        body: |
+          You usually have to apply to the tribunal within 3 months of your employment ending or the problem happening.
+      have_you_contacted_acas:
+        header: Have you contacted ACAS?
+        body: |
+          In most cases, you need to contact Acas for conciliation before the tribunal can consider your application. [Learn about ACAS](/guide#acas_early_conciliation)
       what_you_need_to_know: 
         body: |
           ## Before you start
-          * This is not a free service. [Find out about fees](/guide/#guide-fees)
+          * This is not a free service. [Find out about fees](/guide#fees)
           
           You'll need:
 


### PR DESCRIPTION
- [x] Your fee page - remission help text
- [x] Sign out page - h2 copy change
- [x] Start your claim page - how we use your information text show/hide updated
- [x] Start your claim page - Learn about Acas link
- [x] Start your claim page - removed link text 'when can I apply' 
- [x] Start your claim page - There is a fee text + link
- [x] Claim details - what else do I need to include, link to guide
- [x] Claim details - Help text for character limit
- [x] Respondent page - added Acas link to help text
- [x] Moved text for start your claim page from slim file to yml file
