### PR TITLE
Assign correct target on GDS check boxes

### DIFF
--- a/app/inputs/gds_check_boxes_input.rb
+++ b/app/inputs/gds_check_boxes_input.rb
@@ -7,8 +7,12 @@ class GdsCheckBoxesInput < SimpleForm::Inputs::BooleanInput
   def input(wrapper_options = nil)
     template.concat build_hidden_field_for_checkbox
 
-    template.label_tag('div', class: 'block-label') do
+    template.label_tag(label_target, class: 'block-label') do
       build_check_box_without_hidden_field(input_html_options) + inline_label
     end
+  end
+
+  private def label_target
+    "#{self.object_name}_#{attribute_name}"
   end
 end


### PR DESCRIPTION
The for attribute on the label tag needs to reference the input fields id for the click action to work correctly.

The id of the underlying div is made up of the model name followed by the attribute name, underscored e.g. `my_model_some_attribute`.
