### PR TITLE
Don't blow up on invalid email addresses

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,6 +6,7 @@ Rails.application.initialize!
 
 sending_host = ENV['SENDING_HOST'] || 'localhost'
 
+ActionMailer::Base.raise_delivery_errors = false
 ActionMailer::Base.default_url_options = { host: sending_host, protocol: 'http'}
 ActionMailer::Base.default :from => 'no-reply@digital.justice.gov.uk'
 ActionMailer::Base.smtp_settings = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,9 +13,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
Simple fix to turn off raising on delivery errors. We should handle invalid email addresses on the page. If we can't send to the specified email address(es) there is not a lot we can do. As it's a background job, the user will have already got to the confirmation page and possibly closed the session.
