### PR TITLE
Deprecation warnings were still showing on stdout

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -13,7 +13,7 @@ class Form
   # TODO smarter delegation of this method to take into account delegated
   # attributes, e.g. the ones on address
   def column_for_attribute *args
-    silence_stream(STDERR) do
+    ActiveSupport::Deprecation.silence do
       target.column_for_attribute *args
     end
   end


### PR DESCRIPTION
`column_for_attribute` already returns nil when no attribute (and it looks like we understood this) so really no need for this warning (unless I'm reading it wrong).
