### PR TITLE
Remember selection "was employed" selection on Employment details

### DIFF
--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -10,7 +10,11 @@ class EmploymentForm < Form
 
   dates :start_date, :end_date, :notice_period_end_date, :new_job_start_date
 
-  booleans :was_employed
+  boolean :was_employed
+
+  def was_employed
+    @was_employed ||= resource.employment.present?
+  end
 
   private def target
     resource.employment || resource.build_employment

--- a/spec/forms/employment_form_spec.rb
+++ b/spec/forms/employment_form_spec.rb
@@ -3,4 +3,22 @@ require 'rails_helper'
 RSpec.describe EmploymentForm, :type => :form do
   it_behaves_like 'it parses and validates multiparameter dates',
     :start_date, :end_date, :notice_period_end_date, :new_job_start_date
+
+  subject { described_class.new { |f| f.resource = Claim.new } }
+
+  describe '#was_employed' do
+    context 'when the underlying claim does not have an employment relation' do
+      it 'is false' do
+        expect(subject.was_employed).to be false
+      end
+    end
+
+    context 'when the underlying claim does not have an employment relation' do
+      before { subject.resource.employment = Employment.new }
+
+      it 'is true' do
+        expect(subject.was_employed).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Value of was employed is computed whether or not a employment
  relation exists on the claim. Unfortunately this means it's
  pre-selected as "No" the first time the user gets the page.
  We can revisit this later.
