### PR TITLE
Fix ClaimDetailsForm#other_known_claimants behaviour

### DIFF
--- a/app/forms/claim_details_form.rb
+++ b/app/forms/claim_details_form.rb
@@ -1,11 +1,15 @@
 class ClaimDetailsForm < Form
-  attr_accessor :other_known_claimants
-
   attributes :claim_details, :other_known_claimant_names
 
   validates :claim_details, length: { maximum: 5000 }, presence: true
   validates :other_known_claimant_names, length: { maximum: 350 }
 
+  boolean :other_known_claimants
+
+  def other_known_claimants
+    @other_known_claimants ||= other_known_claimant_names?
+  end
+  
   private def target
     resource
   end

--- a/spec/forms/claim_details_form_spec.rb
+++ b/spec/forms/claim_details_form_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe ClaimDetailsForm, :type => :form do
     end
   end
 
+  describe '#other_known_claimants' do
+    context 'when #other_known_claimant_names is blank' do
+      it 'is false' do
+        expect(subject.other_known_claimants).to be false
+      end
+    end
+
+    context 'when #other_known_claimant_names is not blank' do
+      before { subject.other_known_claimant_names = "Lolly Lollington" }
+
+      it 'is true' do
+        expect(subject.other_known_claimants).to be true
+      end
+    end
+  end
+
   attributes = {
     claim_details: "I want to make a claim",
     other_known_claimants: true,


### PR DESCRIPTION
- Fix is the same as #253.
- Value is computed from ClaimDetailsForm#other_known_claimant_names?
