### PR TITLE
Fix rendering of bit masked attributes (closes #244)

### DIFF
--- a/app/forms/claim_outcome_form.rb
+++ b/app/forms/claim_outcome_form.rb
@@ -3,6 +3,10 @@ class ClaimOutcomeForm < Form
 
   validates :other_outcome, length: { maximum: 2500 }
 
+  def desired_outcomes
+    attributes[:desired_outcomes].map(&:to_s)
+  end
+
   private def target
     resource
   end

--- a/app/forms/claim_type_form.rb
+++ b/app/forms/claim_type_form.rb
@@ -4,6 +4,14 @@ class ClaimTypeForm < Form
   attributes :is_unfair_dismissal, :discrimination_claims, :pay_claims,
     :is_whistleblowing, :send_claim_to_whistleblowing_entity, :other_claim_details
 
+  def discrimination_claims
+    attributes[:discrimination_claims].map(&:to_s)
+  end
+
+  def pay_claims
+    attributes[:pay_claims].map(&:to_s)
+  end
+
   private def target
     resource
   end

--- a/spec/forms/claim_outcome_form_spec.rb
+++ b/spec/forms/claim_outcome_form_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe ClaimOutcomeForm, :type => :form do
 
   it_behaves_like("a Form", attributes, set_resource)
 
+  subject { described_class.new { |f| f.resource = claim } }
+
+  let(:claim) do
+    Claim.new desired_outcomes: %i<compensation_only tribunal_recommendation>
+  end
+
+  describe "#desired_outcomes" do
+    it 'returns the underlying attribute, mapped to_s' do
+      expect(subject.desired_outcomes).
+        to eq claim.desired_outcomes.map(&:to_s)
+    end
+  end
 end

--- a/spec/forms/claim_type_form_spec.rb
+++ b/spec/forms/claim_type_form_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe ClaimTypeForm, :type => :form do
 
   it_behaves_like("a Form", attributes, set_resource)
 
+  subject { described_class.new { |f| f.resource = claim } }
+
+  let(:claim) do
+    Claim.new \
+      discrimination_claims: %i<sex_including_equal_pay disability race>,
+      pay_claims: %i<redundancy notice holiday arrears other>
+  end
+
+
+  %i<pay discrimination>.each do |type|
+    describe "##{type}_claims" do
+      it 'returns the underlying attribute, mapped to_s' do
+        expect(subject.send "#{type}_claims").
+          to eq claim.send("#{type}_claims").map(&:to_s)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Rails form builder appeears to ignore the value of a form
attribute unless it's a string. However symbols are needed for
i18n lookup. The fix is to map to strings in the form object.

Fixes #244 
