### PR TITLE
Fixes save behaviour for RepresentativeForm (fixes #261)

### DIFF
--- a/app/forms/representative_form.rb
+++ b/app/forms/representative_form.rb
@@ -26,6 +26,14 @@ class RepresentativeForm < Form
     end
   end
 
+  def save
+    if has_representative?
+      super
+    else
+      target.destroy
+    end
+  end
+
   private def target
     resource.representative || resource.build_representative
   end

--- a/spec/forms/representative_form_spec.rb
+++ b/spec/forms/representative_form_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe RepresentativeForm, :type => :form do
     end
   end
 
+  describe '#save' do
+    context 'when has_representative? == false' do
+      let(:representative) { Representative.new }
+      before do
+        subject.resource.representative = representative
+        subject.has_representative = false
+      end
+
+      it 'destroys the representative relation' do
+        expect(representative).to receive :destroy
+
+        subject.save
+      end
+    end
+  end
+
   describe 'validations' do
     context 'when has_representative? == true' do
       before { subject.has_representative = true }
@@ -88,7 +104,8 @@ RSpec.describe RepresentativeForm, :type => :form do
     type: 'citizen_advice_bureau', dx_number: '1',
     address_building: '1', address_street: 'High Street',
     address_locality: 'Anytown', address_county: 'Anyfordshire',
-    address_post_code: 'AT1 0AA', email_address: 'lol@example.com' }
+    address_post_code: 'AT1 0AA', email_address: 'lol@example.com',
+    has_representative: true }
 
   before = proc do
     allow(resource).to receive(:representative)


### PR DESCRIPTION
When RepresentaiveForm#has_representative? is false:
- Do not create representative relation on claim
- Destroy relation if exists

When RepresentaiveForm#has_representative? is true:
- Create representative relation on claim
- Do not destroy relation if exists
