### PR TITLE
EmploymentForm fixes

### DIFF
--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -13,7 +13,15 @@ class EmploymentForm < Form
   boolean :was_employed
 
   def was_employed
-    @was_employed ||= resource.employment.present?
+    @was_employed ||= target.persisted?
+  end
+
+  def save
+    if was_employed?
+      super
+    else
+      target.destroy
+    end
   end
 
   private def target

--- a/spec/forms/employment_form_spec.rb
+++ b/spec/forms/employment_form_spec.rb
@@ -6,18 +6,33 @@ RSpec.describe EmploymentForm, :type => :form do
 
   subject { described_class.new { |f| f.resource = Claim.new } }
 
+  before { subject.resource.employment = employment }
+  let(:employment) { Employment.new }
+
   describe '#was_employed' do
-    context 'when the underlying claim does not have an employment relation' do
+
+    context 'when the employment model has not been persisted' do
       it 'is false' do
         expect(subject.was_employed).to be false
       end
     end
 
-    context 'when the underlying claim does not have an employment relation' do
-      before { subject.resource.employment = Employment.new }
+    context 'when the employment model has been persisted' do
+      before { allow(employment).to receive_messages :persisted? => true }
 
       it 'is true' do
         expect(subject.was_employed).to be true
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'when was_employed? == false' do
+      before { subject.was_employed = false }
+
+      it 'destroys the representative relation' do
+        expect(employment).to receive :destroy
+        subject.save
       end
     end
   end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -107,6 +107,8 @@ module FormMethods
   end
 
   def fill_in_employment_details
+    choose  'employment_was_employed_true'
+
     fill_in 'Job or job title', with: 'Super High Powered Exec'
 
     fill_in :employment_start_date_3i, with: '01'


### PR DESCRIPTION
- Do not save employment if user set #was_employed to no
- Destroy existing employment if user set #was_employed to no
- Pre-select no the first time user sees page (instead of yes)
