### PR TITLE
fix: trying to save after destroying records

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -92,10 +92,8 @@ class Form
   def save
     if valid?
       run_callbacks :save do
-        unless target.frozen?
-          target.update_attributes attributes
-          resource.save
-        end
+        target.update_attributes attributes unless target.frozen?
+        resource.save
       end
     else
       false

--- a/spec/support/shared_examples/form.rb
+++ b/spec/support/shared_examples/form.rb
@@ -50,13 +50,15 @@ RSpec.shared_examples 'a Form' do |attributes, block|
 
     context 'when target destroyed' do
       before do
-        allow(form).to receive(:valid?).and_return false
+        allow(form).to receive(:valid?).and_return true
         allow(target).to receive(:frozen?).and_return true
-        allow(resource).to receive(:save)
       end
 
       it 'does not attempt to update the target' do
+        instance_eval &block
+
         expect(target).not_to receive(:update_attributes)
+        expect(form.resource).to receive(:save)
         form.save
       end
     end


### PR DESCRIPTION
Faz reported getting "can't modify frozen Hash" error after selecting 'no' to having a Representative. This is because the association is being destroyed before saving.
