### PR TITLE
Fix Broken Page Titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
-  def page_title(header=I18n.t(".header"))
+  def page_title(header=generic_header)
     "#{header} - Gov.uk"
+  end
+
+  private def generic_header
+    I18n.t("#{controller_name}.#{action_name}.header")
   end
 end


### PR DESCRIPTION
Performs a default lookup for page titles under the assumption a header will be available in the locale file at controller_name.action_name.header.

Fixes #376 

![screen shot 2014-11-18 at 15 57 30](https://cloud.githubusercontent.com/assets/1006365/5090671/b734f150-6f3b-11e4-9abe-ed6c610a04cf.png)
![screen shot 2014-11-18 at 15 57 40](https://cloud.githubusercontent.com/assets/1006365/5090674/b7d000f0-6f3b-11e4-8213-0fea5778f6d8.png)
![screen shot 2014-11-18 at 15 57 53](https://cloud.githubusercontent.com/assets/1006365/5090672/b735f19a-6f3b-11e4-80a5-10dec9cb1f89.png)
