### PR TITLE
Fix edge case on review page

### DIFF
--- a/app/presenters/respondent_presenter.rb
+++ b/app/presenters/respondent_presenter.rb
@@ -10,9 +10,10 @@ class RespondentPresenter < Presenter
   end
 
   def acas_early_conciliation_certificate_number
-    if target.acas_early_conciliation_certificate_number?
+    case
+    when target.acas_early_conciliation_certificate_number?
       target.acas_early_conciliation_certificate_number
-    else
+    when target.no_acas_number_reason
       I18n.t "simple_form.options.respondent.no_acas_number_reason.#{target.no_acas_number_reason}"
     end
   end


### PR DESCRIPTION
Manually navigating to the review page before filling in respondent
details causes all I18n values for no acas number reason. This fixes
that.
