### PR TITLE
Session Prompt Redisplay Bugfix

### DIFF
--- a/app/assets/javascripts/modules/moj.session-prompt.js
+++ b/app/assets/javascripts/modules/moj.session-prompt.js
@@ -15,6 +15,7 @@ module.exports = (function () {
     init: function (options) {
       settings = $.extend(settings, options);
       this.counter = settings.FIVE_MINUTES;
+      this.updateTimeLeftOnPrompt(this.counter);
       this.setPromptExtendSessionClickEvent();
       this.startSessionTimer();
     },
@@ -37,7 +38,7 @@ module.exports = (function () {
         this.expireSession();
       } else {
         this.counter -= settings.SECOND;
-        this.updateTimeLeftOnPrompt(this.counter / settings.SECOND);
+        this.updateTimeLeftOnPrompt(this.counter);
       }
     },
 
@@ -45,8 +46,9 @@ module.exports = (function () {
       $("#session_prompt").toggleClass("hidden");
     },
 
-    updateTimeLeftOnPrompt: function (seconds) {
-      var mins = ~~(seconds / 60);
+    updateTimeLeftOnPrompt: function (timeInMillis) {
+      var seconds = timeInMillis / settings.SECOND;
+      var mins = Math.floor(seconds / 60);
       var secs = seconds % 60;
       var time = (mins === 0) ? secs : (mins + ":" + this.padSeconds(secs));
       $('#session_prompt_time_left').text(time);

--- a/app/views/shared/_session_prompt.html.slim
+++ b/app/views/shared/_session_prompt.html.slim
@@ -1,4 +1,4 @@
 #session_prompt.validation-summary.alert-dialog.hidden role="alertdialog" aria-labelledby="timeoutTitle"
-  h2 = t('session_prompt.header').html_safe
+  h2 = t 'session_prompt.header_html'
   p = t 'session_prompt.session_continue'
   #session_prompt_continue_btn.button.button-primary = t 'session_prompt.session_continue_button'

--- a/config/locales/session_prompt.en.yml
+++ b/config/locales/session_prompt.en.yml
@@ -1,6 +1,6 @@
 en:
   session_prompt:
-    header: |
-      Due to inactivity your session will expire in <span id="session_prompt_time_left">5:00</span>
+    header_html: |
+      Due to inactivity your session will expire in <span id="session_prompt_time_left"></span>
     session_continue: Do you need more time to complete your application?
     session_continue_button: :"simple_form.yes"


### PR DESCRIPTION
- Don’t be tricky and use double bitwise not operator when Math.floor can be used.
- Initialise the prompt with the time to avoid having it in the locale file.
- Initialise the prompt with the time so when it is re displayed it immediately shows the correct timeout left.
- Isolate millis to second conversion only where it is required(updating the time left function).
