### PR TITLE
No cache

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   after_action :set_session_expiry
 
+  before_action do
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"]        = "no-cache"
+    response.headers["Expires"]       = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
+
   class << self
     def redispatch_request(opts={})
       state = opts.delete(:unless)


### PR DESCRIPTION
In response to the pen test, set cache headers as appropriate.
