### PR TITLE
Tick the email confirmation boxes by default

### DIFF
--- a/app/views/claim_reviews/_email_addresses.html.slim
+++ b/app/views/claim_reviews/_email_addresses.html.slim
@@ -6,7 +6,8 @@
       = f.input :email_addresses,
         collection: email_addresses,
         as: :check_boxes,
-        label: false
+        label: false,
+        input_html: { checked: true }
 
     fieldset style="margin-top:60px;"
       legend role="header" aria-level="2" = t('.submit_warning_header')

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -186,7 +186,7 @@ feature 'Claim applications', type: :feature do
 
     scenario 'Emailing confirmation' do
       complete_a_claim seeking_remissions: true
-      select_recipients
+      click_button 'Submit application'
 
       email = ActionMailer::Base.deliveries.last
 
@@ -196,9 +196,21 @@ feature 'Claim applications', type: :feature do
         to eq "application/pdf; charset=UTF-8; filename=et1_barrington_wrigglesworth.pdf"
     end
 
-    scenario 'Submitting claim when no email addresses' do
+    scenario 'Deselecting email confirmations before submission' do
+      ActionMailer::Base.deliveries = []
+
+      complete_a_claim seeking_remissions: true
+      deselect_claimant_email
+      deselect_representative_email
+      click_button 'Submit application'
+
+      expect(ActionMailer::Base.deliveries.size).to eq 0
+    end
+
+    scenario 'Submitting claim when no claimant email address' do
       ActionMailer::Base.deliveries = []
       complete_a_claim seeking_remissions: true, claimant_email: false
+      deselect_representative_email
       click_button 'Submit application'
 
       expect(ActionMailer::Base.deliveries.size).to eq 0

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -263,9 +263,11 @@ module FormMethods
     complete_payment
   end
 
-  def select_recipients
-    check CLAIMANT_EMAIL
-    check REPRESENTATIVE_EMAIL
-    click_button 'Submit application'
+  def deselect_claimant_email
+    uncheck CLAIMANT_EMAIL
+  end
+
+  def deselect_representative_email
+    uncheck REPRESENTATIVE_EMAIL
   end
 end


### PR DESCRIPTION
Checks the claimant and representative email boxes on the claim review page, making the default be to send copies of the completed application. They can be unchecked to inhibit emails.
