### PR TITLE
Jadu::Claim.create submits claims to Jadu.

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,5 @@ PAYMENT_GATEWAY_PING_ENDPOINT=https://mdepayments.epdq.co.uk/ncol/test/backoffic
 EPDQ_PSPID=ministry2
 EPDQ_SECRET_IN="m/mcr\\q]QKE'Pmal;ke2"
 EPDQ_SECRET_OUT="sEtw3k4m.a xl23lmw;la"
+
+JADU_API_HOST="https://etapi.employmenttribunals.service.gov.uk/1/"

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 FEE_GROUP_REFERENCE_SERVICE_URL=https://fgr-stub-service.herokuapp.com/1/fgr-office
+JADU_API_HOST="https://fgr-stub-service.herokuapp.com/1/"

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'capybara'
   gem 'codeclimate-test-reporter', require: nil
   gem 'dotenv-rails'
+  gem 'factory_girl_rails'
   gem 'guard-livereload'
   gem 'launchy'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,11 @@ GEM
     eventmachine (1.0.3)
     excon (0.41.0)
     execjs (2.2.1)
+    factory_girl (4.4.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.4.1)
+      factory_girl (~> 4.4.0)
+      railties (>= 3.0.0)
     ffi (1.9.3)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
@@ -424,6 +429,7 @@ DEPENDENCIES
   compass
   dotenv-rails
   epdq!
+  factory_girl_rails
   fog
   govuk_frontend_toolkit (= 2.0.0)
   guard-livereload

--- a/app/jobs/claim_submission_job.rb
+++ b/app/jobs/claim_submission_job.rb
@@ -1,0 +1,7 @@
+class ClaimSubmissionJob < ActiveJob::Base
+  queue_as :claim_submission
+
+  def perform(claim)
+    Jadu::Claim.create claim
+  end
+end

--- a/app/services/jadu/claim.rb
+++ b/app/services/jadu/claim.rb
@@ -1,0 +1,56 @@
+require_relative 'api'
+
+module Jadu
+  class Claim < Struct.new(:claim)
+    class << self
+      def create(claim)
+        new(claim).tap &:perform
+      end
+    end
+
+    def perform
+      if operation.ok?
+        claim.update fee_group_reference: operation['feeGroupReference'] if operation['feeGroupReference']
+        claim.finalize!
+      else
+        raise StandardError.new <<-EOS.strip_heredoc
+          Application #{claim.reference} was rejected by Jadu with error #{operation['errorCode']}
+          Description: #{operation['errorDescription']}
+          Details: #{operation['details']}
+        EOS
+      end
+    end
+
+    private
+
+    def operation
+      @operation ||= client.new_claim(serialized_claim, attachments)
+    end
+
+    def serialized_claim
+      JaduXml::ClaimPresenter.new(claim).to_xml
+    end
+
+    def claim_pdf
+      @claim_pdf ||= PdfFormBuilder.new(claim)
+    end
+
+    def client
+      API.new ENV.fetch('JADU_API_HOST')
+    end
+
+    def attachments
+      @attachments ||= claim.attachments.reduce({ claim_pdf.filename => claim_pdf.to_pdf }) do |o, a|
+        o.update File.basename(a.url) => a.file.read
+      end
+    end
+
+    def filename_for(attachment)
+      File.basename claim.send(attachment).url
+    end
+
+    def file_contents_for(attachment)
+      claim.send(attachment).file.read
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,104 @@
+FactoryGirl.define do
+  factory :claim do
+    association :primary_claimant,   factory: :claimant, primary_claimant: true
+    association :primary_respondent, factory: :respondent, primary_respondent: true
+    association :representative
+    association :employment
+    association :payment
+    association :office
+
+    state 'enqueued_for_submission'
+
+    is_unfair_dismissal true
+
+    attachment do
+      Rack::Test::UploadedFile.new 'spec/support/files/file.rtf'
+    end
+
+    additional_claimants_csv do
+      Rack::Test::UploadedFile.new 'spec/support/files/file.csv'
+    end
+
+    fee_group_reference { "%010d00" % rand(9999999999) }
+
+    claim_details       'I am sad'
+    other_claim_details 'Really sad'
+    other_outcome       'I wanna take him to the cleaners!'
+    is_whistleblowing   false
+
+    discrimination_claims  %i<sex_including_equal_pay disability race>
+    pay_claims             %i<redundancy notice holiday arrears other>
+    desired_outcomes       %i<compensation_only tribunal_recommendation>
+  end
+
+  factory :claimant do
+    association :address, country: 'United Kingdom'
+
+    title      'mr'
+    first_name 'Barrington'
+    last_name  'Wrigglesworth'
+    gender     'male'
+
+    date_of_birth Date.civil(1960, 6, 6)
+
+    mobile_number      '07956273434'
+    contact_preference 'email'
+    email_address      { "#{first_name}.#{last_name}@example.com" }
+  end
+
+  factory :address do
+    building  '102'
+    street    'Petty France'
+    locality  'London'
+    county    'Greater London'
+    post_code 'SW1A 1AH'
+
+    telephone_number '020 7123 4567'
+  end
+
+  factory :representative do
+    association :address
+
+    type              "law_centre"
+    name              "Saul Goodman"
+    organisation_name "Better Call Saul"
+    dx_number         "1234"
+  end
+
+  factory :respondent do
+    name                    "Ministry of Justice"
+    no_acas_number_reason   "employer_contacted_acas"
+    worked_at_same_address  false
+
+    after(:build) { build_list(:address, 2) }
+  end
+
+  factory :payment do
+    amount 250
+    reference { rand 99999999 }
+  end
+
+  factory :office do
+    name      "Birmingham"
+    address   "Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU"
+    telephone "0121 600 7780"
+  end
+
+  factory :employment do
+    enrolled_in_pension_scheme           true
+    found_new_job                        false
+    worked_notice_period_or_paid_in_lieu false
+    end_date                             3.weeks.ago
+    new_job_start_date                   3.days.ago
+    start_date                           10.years.ago
+    gross_pay                            4000
+    net_pay                              3000
+    new_job_gross_pay                    4000
+    average_hours_worked_per_week        37.5
+    current_situation                    "employment_terminated"
+    gross_pay_period_type                "monthly"
+    job_title                            "tea boy"
+    net_pay_period_type                  "monthly"
+    benefit_details                      "All the justice you can eat"
+  end
+end

--- a/spec/features/payments_spec.rb
+++ b/spec/features/payments_spec.rb
@@ -19,6 +19,11 @@ feature 'Payments:', type: :feature do
 
   describe 'returning from the payment gateway' do
     context 'successfully' do
+      before do
+        # Don't want the job immediately "submitting" the thing
+        allow(ClaimSubmissionJob).to receive(:perform_later)
+      end
+
       before { complete_payment }
 
       it 'redirects to the confirmation page and displays the fee paid' do

--- a/spec/jobs/claim_submission_job_spec.rb
+++ b/spec/jobs/claim_submission_job_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe ClaimSubmissionJob, type: :job do
+  let(:claim) { instance_double Claim }
+
+  describe '#perform' do
+    it 'submits the claim' do
+      expect(Jadu::Claim).to receive(:create).with claim
+      subject.perform(claim)
+    end
+  end
+end

--- a/spec/services/jadu/claim_spec.rb
+++ b/spec/services/jadu/claim_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe Jadu::Claim, type: :service do
+  describe '.create' do
+    let(:api_double) { instance_double Jadu::API }
+    let(:endpoint)   { "https://etapi.employmenttribunals.service.gov.uk/1/" }
+    let(:xml)        { instance_double JaduXml::ClaimPresenter, to_xml: xml_double }
+    let(:xml_double) { double :xml }
+    let(:claim)      { create :claim }
+    let(:pdf_double) { instance_double PdfFormBuilder, to_pdf: 'lol', filename: "et1_barrington_wrigglesworth.pdf" }
+
+    let(:successful_api_response) do
+      double(:successful_api_response, ok?: true).tap do |d|
+        allow(d).to receive(:[])
+      end
+    end
+
+    let(:failure_api_response) do
+      double(:failure_api_response, ok?: false).tap do |d|
+        allow(d).to receive(:[])
+      end
+    end
+
+    let(:attachments) do
+      { "et1_barrington_wrigglesworth.pdf" => 'lol',
+        "file.rtf" => claim.attachment.file.read,
+        "file.csv" => claim.additional_claimants_csv.file.read }
+    end
+
+    before do
+      allow(Jadu::API).to receive(:new).with(endpoint).and_return api_double
+      allow(JaduXml::ClaimPresenter).to receive(:new).with(claim).and_return xml
+      allow(PdfFormBuilder).to receive(:new).with(claim).and_return pdf_double
+    end
+
+    describe '.create' do
+      it 'submits a claim to Jadu' do
+        expect(api_double).to receive(:new_claim).
+          with(xml_double, attachments).and_return successful_api_response
+
+        Jadu::Claim.create claim
+      end
+
+      describe 'on failure' do
+        before do
+          allow(api_double).to receive(:new_claim).
+            with(xml_double, attachments).and_return failure_api_response
+        end
+
+        it 'raises an execption' do
+          expect { Jadu::Claim.create claim }.to raise_error StandardError
+        end
+
+        it 'does not update the claim' do
+          expect(claim).not_to receive(:update)
+
+          begin
+            Jadu::Claim.create claim
+          rescue StandardError
+          end
+        end
+
+        it 'does not finalize the claim' do
+          expect(claim).not_to receive(:finalize!)
+
+          begin
+            Jadu::Claim.create claim
+          rescue StandardError
+          end
+        end
+      end
+
+      describe 'on success' do
+        before do
+          allow(api_double).to receive(:new_claim).
+            with(xml_double, attachments).and_return successful_api_response
+        end
+
+        it 'finalizes the claim' do
+          expect(claim).to receive(:finalize!)
+          Jadu::Claim.create claim
+        end
+
+        describe 'when the API returns a fee group reference' do
+          before do
+            allow(successful_api_response).to receive(:[]).
+              with('feeGroupReference').and_return 123456789000
+          end
+
+          it 'updates the claim fee group reference' do
+            expect(claim).to receive(:update).with fee_group_reference: 123456789000
+
+            Jadu::Claim.create claim
+          end
+        end
+
+        describe 'when the API does not return a fee group reference' do
+          it 'updates the claim fee group reference' do
+            expect(claim).not_to receive(:update).with fee_group_reference: 123456789000
+
+            Jadu::Claim.create claim
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -16,7 +16,17 @@ module FormMethods
       }
     end
 
+    let(:submission_response) do
+      {
+        "feeGroupReference" => 511234567800,
+        "status" => 'ok'
+      }
+    end
+
     before do
+      stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/new-claim').
+        to_return(body: submission_response.to_json, headers: { 'Content-Type' => 'application/json' })
+
       stub_request(:post, 'https://etapi.employmenttribunals.service.gov.uk/1/fgr-office').
         with(postcode: 'AT1 4PQ').
         to_return(body: fgr_response.to_json, headers: { 'Content-Type' => 'application/json' })
@@ -237,8 +247,6 @@ module FormMethods
       'SHASIGN=A8410E130DA5C6AB210CF8E64CAFA64EC8AC8EFF0D958AC0D2CB3AF3EE467E75'
 
     visit path
-
-    raise "Gateway redirect invalid" if page.current_url.sub(page.current_host, '') == path
   end
 
   def complete_a_claim(options={})


### PR DESCRIPTION
Jadu::Claim.create is just a wrapper around the work of others
so the specs just assert the relevant methods are called on
the collaborator objects. I don't like testing with a lot of
doubles because it's brittle, but I also don't like duplicating
tests already extant. I have attended to the brittleness risk
by using instance_doubles with check the doubled object responds
to mocked methods.
