### PR TITLE
Claim Assosciated pdf

### DIFF
--- a/app/controllers/claim_confirmations_controller.rb
+++ b/app/controllers/claim_confirmations_controller.rb
@@ -6,11 +6,4 @@ class ClaimConfirmationsController < ApplicationController
   end
 
   helper_method :fee_calculation
-
-  def generated_claim
-    respond_to do |format|
-      pdf_form = PdfFormBuilder.new(claim)
-      format.pdf { render pdf: pdf_form, filename: pdf_form.filename }
-    end
-  end
 end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -1,0 +1,7 @@
+class PdfsController < ApplicationController
+  redispatch_request unless: :immutable?
+
+  def show
+    redirect_to claim.pdf_url if claim.pdf_present?
+  end
+end

--- a/app/jobs/claim_submission_job.rb
+++ b/app/jobs/claim_submission_job.rb
@@ -2,6 +2,7 @@ class ClaimSubmissionJob < ActiveJob::Base
   queue_as :claim_submission
 
   def perform(claim)
+    claim.generate_pdf!
     Jadu::Claim.create claim
   end
 end

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -9,8 +9,8 @@ class BaseMailer < ActionMailer::Base
 
   def confirmation_email(claim, email_addresses)
     @claim = claim
-    pdf_form = PdfFormBuilder.new(@claim)
-    attachments[pdf_form.filename] = pdf_form.to_pdf
+    @claim.generate_pdf!
+    attachments[@claim.pdf_filename] = @claim.pdf_file.read
     mail(to: email_addresses, subject: t('base_mailer.confirmation_email.subject'))
   end
 end

--- a/app/services/jadu/claim.rb
+++ b/app/services/jadu/claim.rb
@@ -31,16 +31,12 @@ module Jadu
       JaduXml::ClaimPresenter.new(claim).to_xml
     end
 
-    def claim_pdf
-      @claim_pdf ||= PdfFormBuilder.new(claim)
-    end
-
     def client
       API.new ENV.fetch('JADU_API_HOST')
     end
 
     def attachments
-      @attachments ||= claim.attachments.reduce({ claim_pdf.filename => claim_pdf.to_pdf }) do |o, a|
+      @attachments ||= claim.attachments.reduce({}) do |o, a|
         o.update File.basename(a.url) => a.file.read
       end
     end

--- a/app/services/pdf_form_builder.rb
+++ b/app/services/pdf_form_builder.rb
@@ -1,18 +1,33 @@
-class PdfFormBuilder
-  def initialize(claim)
-    @pdftk = PdfForms.new('pdftk')
-    @claim = claim
-    @presenter = PdfForm::ClaimPresenter.new(@claim)
+class PdfFormBuilder < Struct.new(:claim)
+  ET1_PDF_PATH = "#{Rails.root}/lib/assets/et001-eng.pdf".freeze
+
+  class << self
+    def build(claim, &block)
+      new(claim).tap { |p| p.perform &block }
+    end
   end
 
-  def filename
-    "et1_#{@presenter.name.downcase.gsub(' ', '_')}.pdf"
+  def perform(&_block)
+    pdf_builder.fill_form(ET1_PDF_PATH, tempfile, document_data, flatten: !Rails.env.test?)
+    yield tempfile
+    tempfile.close!
   end
 
-  def to_pdf
-    fields = @presenter.to_h
-    pdf_path =  "tmp/claim#{@claim.id}.pdf"
-    @pdftk.fill_form('lib/assets/et001-eng.pdf', pdf_path, fields, flatten: !Rails.env.test?)
-    File.read(pdf_path)
+  private
+
+  def pdf_builder
+    @pdf_builder ||= PdfForms.new('pdftk')
+  end
+
+  def presenter
+    @presenter ||= PdfForm::ClaimPresenter.new(claim)
+  end
+
+  def document_data
+    presenter.to_h
+  end
+
+  def tempfile
+    @tempfile ||= Tempfile.new("#{claim.id}.pdf")
   end
 end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,49 +1,4 @@
 # encoding: utf-8
 
 class AttachmentUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.reference}"
-  end
-
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process :scale => [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process :resize_to_fit => [50, 50]
-  # end
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  # def extension_white_list
-  #   %w(jpg jpeg gif png)
-  # end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
 end

--- a/app/uploaders/claim_pdf_uploader.rb
+++ b/app/uploaders/claim_pdf_uploader.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+class ClaimPdfUploader < CarrierWave::Uploader::Base
+  def filename
+    if file && claimant
+      name = "#{claimant.first_name}_#{claimant.last_name}".downcase
+      "et1_#{name}.pdf"
+    end
+  end
+
+  private def claimant
+    model.primary_claimant
+  end
+end

--- a/app/views/claim_confirmations/show.html.slim
+++ b/app/views/claim_confirmations/show.html.slim
@@ -24,8 +24,7 @@ header.main-header
         caption = t('.submission_details.header')
         tr role="row"
           th = t '.download_application.header'
-          td = t '.download_application.link_html',
-            href: generated_claim_claim_confirmation_url(claim, format: 'pdf')
+          td = t '.download_application.link_html', href: pdf_path, target: "_blank"
 
         - confirmation_presenter.each_item do |name, content|
           tr role="row"

--- a/app/views/payments/show.html.slim
+++ b/app/views/payments/show.html.slim
@@ -25,9 +25,7 @@ header.main-header
         p= t('.details.intro')
         h2.bold-medium= t('.details.heading')
         ul
-          li= t('.details.li_one_link',
-            link: link_to(t('.details.li_one'),
-            generated_claim_claim_confirmation_url(claim, format: 'pdf'))).html_safe
+          li= t('.details.li_one_link_html', link: link_to(t('.details.li_one'), pdf_path))
           li= t('.details.li_two')
           li= t '.details.li_three_html',
             link: link_to('Employment Tribunals Office (Scotland)', 'https://www.justice.gov.uk/tribunals/employment/venues')

--- a/app/views/pdfs/show.html.slim
+++ b/app/views/pdfs/show.html.slim
@@ -1,0 +1,11 @@
+- content_for :head do
+  meta http-equiv="refresh" content="5; url=#{pdf_path}"
+
+- content_for(:page_title, page_title)
+
+header.main-header
+  h1= t '.header'
+
+.main-content
+  p = t '.will_redirect'
+  p = t '.email_entered'

--- a/config/carrierwave.yml
+++ b/config/carrierwave.yml
@@ -1,0 +1,19 @@
+default: &default
+  storage: :file
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  fog_credentials:
+    provider:                       'AWS'
+    aws_access_key_id:              <%= ENV.fetch('AWS_ACCESS_KEY_ID') %>
+    aws_secret_access_key:          <%= ENV.fetch('AWS_SECRET_ACCESS_KEY') %>
+    fog_directory:                  <%= ENV.fetch('S3_UPLOAD_BUCKET') %>
+    region:                         'eu-west-1'
+  fog_public:                       false
+  fog_authenticated_url_expiration: <%= ENV.fetch('S3_URL_EXPIRY') || 60 %>
+  storage:                          :fog

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,13 +1,18 @@
-if Rails.env.production?
-  CarrierWave.configure do |config|
-    config.fog_credentials = {
-      provider:              'AWS',
-      aws_access_key_id:     ENV.fetch('AWS_ACCESS_KEY_ID'),
-      aws_secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
-      region:                'eu-west-1',
-    }
-    config.fog_directory  = ENV.fetch('S3_UPLOAD_BUCKET')
-    config.fog_public     = false
-    config.storage :fog
+CarrierWave.configure do |config|
+  properties = "#{Rails.root}/config/carrierwave.yml"
+  YAML.load_file(properties)[Rails.env].each { |k, v| config.send "#{k}=", v }
+
+  Dir["#{Rails.root}/app/uploaders/*.rb"].each { |file| require file }
+
+  CarrierWave::Uploader::Base.descendants.each do |klass|
+    klass.class_eval do
+      def store_dir
+        if Rails.env.test?
+          "spec/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.reference}"
+        else
+          "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.reference}"
+        end
+      end
+    end
   end
 end

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -13,7 +13,7 @@ en:
 
       download_application:
         header: Download your application
-        link_html: <a href="%{href}">Save a copy</a> for your records
+        link_html: <a href="%{href}" target="%{target}">Save a copy</a> for your records 
 
       submission_details:
         header: Submission details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,7 +637,7 @@ en:
         intro: You can pay by cheque
         heading: "You will need to:"
         li_one: completed application
-        li_one_link: "print the %{link}"
+        li_one_link_html: "print the %{link}"
         li_two: include a cheque for the correct issue fee
         li_three_html: post the claim to tribunal office %{link}
     decline:

--- a/config/locales/pdfs.en.yml
+++ b/config/locales/pdfs.en.yml
@@ -1,0 +1,8 @@
+en:
+  pdfs:
+    show:
+      header: Processing a copy of your claim
+      will_redirect: |
+        You will be redirected to a copy of your claim. Do not navigate away from this page.
+      email_entered: |
+        If you entered an email address before submitting you will be sent a copy of your claim in an email.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,9 @@ Rails.application.routes.draw do
   scope :apply do
     resource :claim_review, only: %i<show update>, path: :review
 
-    resource :claim_confirmation, only: :show, path: :confirmation do
-      get 'generated_claim', on: :member
-    end
+    resource :claim_confirmation, only: :show, path: :confirmation
+
+    resource :pdf, only: :show
 
     resource :claim, only: :create, path: "/" do
       resource :payment, only: %i<show update>, path: :pay do

--- a/db/migrate/20141201210140_add_pdf_to_claims.rb
+++ b/db/migrate/20141201210140_add_pdf_to_claims.rb
@@ -1,0 +1,5 @@
+class AddPdfToClaims < ActiveRecord::Migration
+  def change
+    add_column :claims, :pdf, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,46 +11,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141127153025) do
+ActiveRecord::Schema.define(version: 20141201210140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "addresses", force: true do |t|
-    t.string   "building",         limit: 255
-    t.string   "street",           limit: 255
-    t.string   "locality",         limit: 255
-    t.string   "county",           limit: 255
-    t.string   "post_code",        limit: 255
+    t.string   "building"
+    t.string   "street"
+    t.string   "locality"
+    t.string   "county"
+    t.string   "post_code"
     t.integer  "addressable_id"
-    t.string   "addressable_type", limit: 255
+    t.string   "addressable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "telephone_number", limit: 255
-    t.string   "country",          limit: 255
+    t.string   "telephone_number"
+    t.string   "country"
   end
 
   create_table "claimants", force: true do |t|
-    t.string   "first_name",         limit: 255
-    t.string   "last_name",          limit: 255
+    t.string   "first_name"
+    t.string   "last_name"
     t.date     "date_of_birth"
-    t.string   "mobile_number",      limit: 255
-    t.string   "fax_number",         limit: 255
-    t.string   "email_address",      limit: 255
+    t.string   "mobile_number"
+    t.string   "fax_number"
+    t.string   "email_address"
     t.text     "special_needs"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "claim_id"
-    t.string   "gender",             limit: 255
-    t.string   "contact_preference", limit: 255
-    t.string   "title",              limit: 255
-    t.boolean  "primary_claimant",               default: false
+    t.string   "gender"
+    t.string   "contact_preference"
+    t.string   "title"
+    t.boolean  "primary_claimant",   default: false
   end
 
   create_table "claims", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "password_digest",                       limit: 255
+    t.string   "password_digest"
     t.boolean  "is_unfair_dismissal"
     t.integer  "discrimination_claims"
     t.integer  "pay_claims"
@@ -67,11 +67,12 @@ ActiveRecord::Schema.define(version: 20141127153025) do
     t.datetime "submitted_at"
     t.string   "attachment"
     t.string   "email_address"
-    t.integer  "remission_claimant_count",                          default: 0
     t.string   "additional_claimants_csv"
-    t.integer  "additional_claimants_csv_record_count",             default: 0
-    t.string   "application_reference",                                         null: false
-    t.integer  "payment_attempts",                                  default: 0
+    t.integer  "remission_claimant_count",              default: 0
+    t.integer  "additional_claimants_csv_record_count", default: 0
+    t.string   "application_reference",                             null: false
+    t.integer  "payment_attempts",                      default: 0
+    t.string   "pdf"
   end
 
   add_index "claims", ["application_reference"], name: "index_claims_on_application_reference", unique: true, using: :btree
@@ -89,12 +90,12 @@ ActiveRecord::Schema.define(version: 20141127153025) do
     t.integer  "net_pay"
     t.integer  "new_job_gross_pay"
     t.float    "average_hours_worked_per_week"
-    t.string   "current_situation",                    limit: 255
-    t.string   "gross_pay_period_type",                limit: 255
-    t.string   "job_title",                            limit: 255
-    t.string   "net_pay_period_type",                  limit: 255
-    t.string   "new_job_gross_pay_frequency",          limit: 255
-    t.string   "notice_pay_period_type",               limit: 255
+    t.string   "current_situation"
+    t.string   "gross_pay_period_type"
+    t.string   "job_title"
+    t.string   "net_pay_period_type"
+    t.string   "new_job_gross_pay_frequency"
+    t.string   "notice_pay_period_type"
     t.text     "benefit_details"
     t.integer  "claim_id"
     t.datetime "created_at"
@@ -120,27 +121,27 @@ ActiveRecord::Schema.define(version: 20141127153025) do
   end
 
   create_table "representatives", force: true do |t|
-    t.string   "type",               limit: 255
-    t.string   "organisation_name",  limit: 255
-    t.string   "name",               limit: 255
-    t.string   "mobile_number",      limit: 255
-    t.string   "email_address",      limit: 255
-    t.string   "dx_number",          limit: 255
+    t.string   "type"
+    t.string   "organisation_name"
+    t.string   "name"
+    t.string   "mobile_number"
+    t.string   "email_address"
+    t.string   "dx_number"
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "contact_preference", limit: 255
+    t.string   "contact_preference"
   end
 
   create_table "respondents", force: true do |t|
-    t.string   "name",                                       limit: 255
-    t.string   "acas_early_conciliation_certificate_number", limit: 255
-    t.string   "no_acas_number_reason",                      limit: 255
+    t.string   "name"
+    t.string   "acas_early_conciliation_certificate_number"
+    t.string   "no_acas_number_reason"
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "worked_at_same_address",                                 default: true
-    t.boolean  "primary_respondent",                                     default: false
+    t.boolean  "worked_at_same_address",                     default: true
+    t.boolean  "primary_respondent",                         default: false
   end
 
 end

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -228,13 +228,23 @@ feature 'Claim applications', type: :feature do
       expect(page).to have_text     "Get help with paying your fee now"
     end
 
-    scenario 'Downloading the PDF' do
+    scenario 'Downloading the PDF if available' do
       complete_a_claim seeking_remissions: true
       click_button 'Submit application'
       click_link 'Save a copy'
 
       expect(page.response_headers['Content-Type']).to eq "application/pdf"
       expect(pdf_to_hash(page.body)).to eq(YAML.load(File.read('spec/support/et1_pdf_example.yml')))
+    end
+
+    scenario 'Downloading the PDF if unavailable' do
+      complete_a_claim seeking_remissions: true
+      click_button 'Submit application'
+      block_pdf_generation
+      click_link 'Save a copy'
+
+      expect(current_url).to match pdf_path
+      expect(page).to have_text "Processing a copy of your claim"
     end
 
     scenario 'Viewing the confirmation page when seeking remission' do

--- a/spec/features/xml_generation_spec.rb
+++ b/spec/features/xml_generation_spec.rb
@@ -42,10 +42,10 @@ feature 'XML Generation' do
       doc.remove_namespaces!
 
       expect(doc.xpath("//Filename").children.map(&:to_s)).
-        to match_array %w<file.csv file.rtf>
+        to match_array %w<file.csv file.rtf et1_barrington_wrigglesworth.pdf>
 
       expect(doc.xpath("//Checksum").children.map(&:to_s)).
-        to match_array %w<ee7d09ca06cab35f40f4a6b6d76704a7 58d5af93e8ee5b89e93eb13b750f8301>
+        to match_array %w<ee7d09ca06cab35f40f4a6b6d76704a7 58d5af93e8ee5b89e93eb13b750f8301 65b207906e0f13adc32a439cc7413830>
     end
   end
 end

--- a/spec/jobs/claim_submission_job_spec.rb
+++ b/spec/jobs/claim_submission_job_spec.rb
@@ -5,6 +5,7 @@ describe ClaimSubmissionJob, type: :job do
 
   describe '#perform' do
     it 'submits the claim' do
+      expect(claim).to receive(:generate_pdf!)
       expect(Jadu::Claim).to receive(:create).with claim
       subject.perform(claim)
     end

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -26,105 +26,115 @@ describe BaseMailer do
     end
 
     it 'has reference in the subject' do
-      expect(email.subject).to include claim.reference
+      expect(email.subject).to have_text claim.reference
     end
 
     it 'has reference in body' do
-      expect(email.body).to include claim.reference
+      expect(email.body).to have_text claim.reference
     end
   end
 
   describe '#confirmation_email' do
     let(:email_addresses) { ['bill@example.com', 'mike@example.com'] }
-    subject { described_class.confirmation_email(claim, email_addresses) }
     let(:content) { email.parts.find { |p| p.content_type.match(/html/) }.body.raw_source }
-    let(:attachment) { email.parts.find { |p| p.filename == 'filename' }.body.raw_source }
+    let(:attachment) { email.parts.find(&:filename) }
+
+    subject { described_class.confirmation_email(claim, email_addresses) }
 
     before do
       allow(claim).to receive(:payment_applicable?).and_return false
       allow(claim).to receive(:remission_applicable?).and_return false
-      pdf_form = double filename: 'filename', to_pdf: 'pdf'
-      allow(PdfFormBuilder).to receive(:new).with(claim).and_return pdf_form
+      allow(claim).to receive(:pdf_filename).and_return "such.pdf"
+      allow(claim).to receive(:pdf_file).and_return Tempfile.new('such.pdf')
     end
 
-    it 'has been delivered' do
-      email
-      expect(ActionMailer::Base.deliveries).to be_present
-    end
-
-    it 'has recipients' do
-      expect(email.to).to eq email_addresses
-    end
-
-    it 'has reference in the body' do
-      expect(content).to include claim.reference
-    end
-
-    it 'has office' do
-      expect(content).to include 'Birmingham'
-      expect(content).to include 'Phoenix House'
-    end
-
-    it 'has attachment' do
-      expect(attachment).to eq('pdf')
-    end
-
-    context 'when no office' do
-      let(:office) { nil }
-
-      it 'does not show office details' do
-        expect(content).not_to include table_heading('office')
+    context "pre delivery" do
+      it 'attempts pdf generation on the claim' do
+        expect(claim).to receive(:generate_pdf!)
+        subject.deliver_now
       end
     end
 
-    context 'when paid' do
-      before do
-        claim.payment = Payment.new(amount: 100)
+    context "post delivery" do
+      it 'has been delivered' do
+        email
+        expect(ActionMailer::Base.deliveries).to be_present
       end
 
-      it 'shows paid message' do
-        expect(content).
-          to include "Thank you for your payment. We’ll write to you within 5 working days."
+      it 'has recipients' do
+        expect(email.to).to eq email_addresses
       end
 
-      it 'shows amount paid' do
-        expect(content).to include '100'
-      end
-    end
-
-    context 'when applying for remission' do
-      before do
-        allow(claim).to receive(:remission_applicable?).and_return true
-        allow(claim).to receive(:payment_applicable?).and_return false
+      it 'has reference in the body' do
+        expect(content).to have_text claim.reference
       end
 
-      it 'shows remission help' do
-        expect(content).to include 'Get help with paying your fee'
+      it 'has office' do
+        expect(content).to have_text 'Birmingham'
+        expect(content).to have_text 'Phoenix House'
       end
 
-      it 'does not show any payment information' do
-        expect(content).not_to include payment_message
-        expect(content).not_to include table_heading('fee_paid')
-        expect(content).not_to include table_heading('fee_to_pay')
-      end
-    end
-
-    context 'when payment failed' do
-      let(:fee_calculation) { double application_fee: 100 }
-
-      before do
-        allow(claim).to receive(:payment_applicable?).and_return true
-        allow(claim).to receive(:fee_calculation).and_return fee_calculation
+      it 'has attachment' do
+        expect(attachment.filename).to eq('such.pdf')
       end
 
-      it 'does not show any paid information' do
-        expect(content).not_to include payment_message
-        expect(content).not_to include table_heading('fee_paid')
+      context 'when no office' do
+        let(:office) { nil }
+
+        it 'does not show office details' do
+          expect(content).not_to have_text table_heading('office')
+        end
       end
 
-      it 'shows outstanding fee' do
-        expect(content).to include 'Fee to pay'
-        expect(content).to include '100'
+      context 'when paid' do
+        before do
+          claim.payment = Payment.new(amount: 100)
+        end
+
+        it 'shows paid message' do
+          expect(content).
+            to have_text "Thank you for your payment. We’ll write to you within 5 working days."
+        end
+
+        it 'shows amount paid' do
+          expect(content).to have_text '100'
+        end
+      end
+
+      context 'when applying for remission' do
+        before do
+          allow(claim).to receive(:remission_applicable?).and_return true
+          allow(claim).to receive(:payment_applicable?).and_return false
+        end
+
+        it 'shows remission help' do
+          expect(content).to have_text 'Get help with paying your fee'
+        end
+
+        it 'does not show any payment information' do
+          expect(content).not_to have_text payment_message
+          expect(content).not_to have_text table_heading('fee_paid')
+          expect(content).not_to have_text table_heading('fee_to_pay')
+        end
+      end
+
+      context 'when payment failed' do
+        let(:fee_calculation) { double application_fee: 100 }
+
+        before do
+          allow(claim).to receive(:payment_applicable?).and_return true
+          allow(claim).to receive(:fee_calculation).and_return fee_calculation
+        end
+
+        it 'does not show any paid information' do
+          expect(content).not_to have_text payment_message
+          expect(content).not_to have_text table_heading('fee_paid')
+        end
+
+        it 'shows outstanding fee' do
+          expect(content).to have_text 'Fee to pay'
+          expect(content).to have_text '100'
+        end
       end
     end
   end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -236,6 +236,25 @@ RSpec.describe Claim, :type => :claim do
     end
   end
 
+  describe "#generate_pdf!" do
+    context "pdf has already been generated" do
+      it "does not attempt to generate another" do
+        allow(subject).to receive(:pdf_blank?).and_return false
+        expect(PdfFormBuilder).not_to receive(:build)
+        subject.generate_pdf!
+      end
+    end
+
+    context "pdf has yet to be generated" do
+      it "assigns a pdf to the model" do
+        subject = create :claim
+        subject.generate_pdf!
+
+        expect(subject.pdf_filename).to eq "et1_barrington_wrigglesworth.pdf"
+      end
+    end
+  end
+
   describe '#submit!' do
     context 'transitioning state from "created"' do
       context 'when the claim is in a submittable state' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,8 +17,6 @@ require 'shoulda/matchers'
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-CarrierWave.root = "#{Rails.root}/spec/support"
-
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
@@ -52,6 +50,6 @@ RSpec.configure do |config|
   end
 
   config.after(:all) do
-    FileUtils.rm_rf(Dir["#{CarrierWave.root}/uploads/[^.]*"])
+    FileUtils.rm_rf(Dir["#{Rails.root}/public/spec/uploads/[^.]*"])
   end
 end

--- a/spec/services/jadu/claim_spec.rb
+++ b/spec/services/jadu/claim_spec.rb
@@ -1,105 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe Jadu::Claim, type: :service do
+  let(:api_double) { instance_double Jadu::API }
+  let(:endpoint)   { "https://etapi.employmenttribunals.service.gov.uk/1/" }
+  let(:xml)        { instance_double JaduXml::ClaimPresenter, to_xml: xml_double }
+  let(:xml_double) { double :xml }
+  let(:claim)      { create :claim }
+
+  let(:successful_api_response) do
+    double(:successful_api_response, ok?: true).tap do |d|
+      allow(d).to receive(:[])
+    end
+  end
+
+  let(:failure_api_response) do
+    double(:failure_api_response, ok?: false).tap do |d|
+      allow(d).to receive(:[])
+    end
+  end
+
+  let(:attachments) do
+    { "et1_barrington_wrigglesworth.pdf" => claim.pdf_file.read,
+      "file.rtf" => claim.attachment_file.read,
+      "file.csv" => claim.additional_claimants_csv_file.read }
+  end
+
+  before do
+    claim.generate_pdf!
+    allow(Jadu::API).to receive(:new).with(endpoint).and_return api_double
+    allow(JaduXml::ClaimPresenter).to receive(:new).with(claim).and_return xml
+  end
+
   describe '.create' do
-    let(:api_double) { instance_double Jadu::API }
-    let(:endpoint)   { "https://etapi.employmenttribunals.service.gov.uk/1/" }
-    let(:xml)        { instance_double JaduXml::ClaimPresenter, to_xml: xml_double }
-    let(:xml_double) { double :xml }
-    let(:claim)      { create :claim }
-    let(:pdf_double) { instance_double PdfFormBuilder, to_pdf: 'lol', filename: "et1_barrington_wrigglesworth.pdf" }
+    it 'submits a claim to Jadu' do
+      expect(api_double).to receive(:new_claim).
+        with(xml_double, attachments).and_return successful_api_response
 
-    let(:successful_api_response) do
-      double(:successful_api_response, ok?: true).tap do |d|
-        allow(d).to receive(:[])
+      Jadu::Claim.create claim
+    end
+
+    describe 'on failure' do
+      before do
+        allow(api_double).to receive(:new_claim).
+          with(xml_double, attachments).and_return failure_api_response
+      end
+
+      it 'raises an execption' do
+        expect { Jadu::Claim.create claim }.to raise_error StandardError
+      end
+
+      it 'does not update the claim' do
+        expect(claim).not_to receive(:update)
+
+        begin
+          Jadu::Claim.create claim
+        rescue StandardError
+        end
+      end
+
+      it 'does not finalize the claim' do
+        expect(claim).not_to receive(:finalize!)
+
+        begin
+          Jadu::Claim.create claim
+        rescue StandardError
+        end
       end
     end
 
-    let(:failure_api_response) do
-      double(:failure_api_response, ok?: false).tap do |d|
-        allow(d).to receive(:[])
-      end
-    end
-
-    let(:attachments) do
-      { "et1_barrington_wrigglesworth.pdf" => 'lol',
-        "file.rtf" => claim.attachment.file.read,
-        "file.csv" => claim.additional_claimants_csv.file.read }
-    end
-
-    before do
-      allow(Jadu::API).to receive(:new).with(endpoint).and_return api_double
-      allow(JaduXml::ClaimPresenter).to receive(:new).with(claim).and_return xml
-      allow(PdfFormBuilder).to receive(:new).with(claim).and_return pdf_double
-    end
-
-    describe '.create' do
-      it 'submits a claim to Jadu' do
-        expect(api_double).to receive(:new_claim).
+    describe 'on success' do
+      before do
+        allow(api_double).to receive(:new_claim).
           with(xml_double, attachments).and_return successful_api_response
+      end
 
+      it 'finalizes the claim' do
+        expect(claim).to receive(:finalize!)
         Jadu::Claim.create claim
       end
 
-      describe 'on failure' do
+      describe 'when the API returns a fee group reference' do
         before do
-          allow(api_double).to receive(:new_claim).
-            with(xml_double, attachments).and_return failure_api_response
+          allow(successful_api_response).to receive(:[]).
+            with('feeGroupReference').and_return 123456789000
         end
 
-        it 'raises an execption' do
-          expect { Jadu::Claim.create claim }.to raise_error StandardError
-        end
+        it 'updates the claim fee group reference' do
+          expect(claim).to receive(:update).with fee_group_reference: 123456789000
 
-        it 'does not update the claim' do
-          expect(claim).not_to receive(:update)
-
-          begin
-            Jadu::Claim.create claim
-          rescue StandardError
-          end
-        end
-
-        it 'does not finalize the claim' do
-          expect(claim).not_to receive(:finalize!)
-
-          begin
-            Jadu::Claim.create claim
-          rescue StandardError
-          end
+          Jadu::Claim.create claim
         end
       end
 
-      describe 'on success' do
-        before do
-          allow(api_double).to receive(:new_claim).
-            with(xml_double, attachments).and_return successful_api_response
-        end
+      describe 'when the API does not return a fee group reference' do
+        it 'updates the claim fee group reference' do
+          expect(claim).not_to receive(:update).with fee_group_reference: 123456789000
 
-        it 'finalizes the claim' do
-          expect(claim).to receive(:finalize!)
           Jadu::Claim.create claim
-        end
-
-        describe 'when the API returns a fee group reference' do
-          before do
-            allow(successful_api_response).to receive(:[]).
-              with('feeGroupReference').and_return 123456789000
-          end
-
-          it 'updates the claim fee group reference' do
-            expect(claim).to receive(:update).with fee_group_reference: 123456789000
-
-            Jadu::Claim.create claim
-          end
-        end
-
-        describe 'when the API does not return a fee group reference' do
-          it 'updates the claim fee group reference' do
-            expect(claim).not_to receive(:update).with fee_group_reference: 123456789000
-
-            Jadu::Claim.create claim
-          end
         end
       end
     end

--- a/spec/services/pdf_form_builder_spec.rb
+++ b/spec/services/pdf_form_builder_spec.rb
@@ -1,35 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe PdfFormBuilder, type: :service do
-  let(:pdf_forms) { double fill_form: nil }
-  let(:claim) { double id: 1 }
-  let(:claim_presenter) { double name: 'name', to_h: { fields: 'fields' } }
-  let(:et1_pdf_path) { 'lib/assets/et001-eng.pdf' }
-  subject { described_class.new(claim) }
 
-  before do
-    allow(File).to receive(:read).and_return('pdf')
-    allow(PdfForms).to receive(:new).and_return(pdf_forms)
-    allow(PdfForm::ClaimPresenter).to receive(:new).and_return(claim_presenter)
-  end
+  context "ET1 Form template" do
+    describe "ET1_PDF_PATH" do
+      it "returns the path of the template form pdf" do
+        expect(described_class::ET1_PDF_PATH).to eq "#{Rails.root}/lib/assets/et001-eng.pdf"
+      end
+    end
 
-  describe '#filename' do
-    it 'returns a filename' do
-      expect(subject.filename).to eq('et1_name.pdf')
+    it "exists" do
+      file_existence = File.exist?(described_class::ET1_PDF_PATH)
+      expect(file_existence).to eq true
     end
   end
 
-  describe '#to_pdf' do
-    it 'returns filled in ET1 pdf' do
-      pdf = subject.to_pdf
+  describe ".build" do
 
-      expect(pdf).to eq('pdf')
-      expect(pdf_forms).to have_received(:fill_form).with(
-        et1_pdf_path, 'tmp/claim1.pdf', { fields: 'fields' }, flatten: false)
+    let(:claim) { create :claim }
+
+    it "creates an instance" do
+      expect(described_class).to receive(:new).and_call_original
+      described_class.build(claim) {}
     end
 
-    it 'ensure ET1 PDF exists' do
-      expect(File).to exist(et1_pdf_path)
+    context "#perform" do
+      it "yields a pdf to the given block" do
+        described_class.build(claim) do |file|
+          expect(file).to be_kind_of Tempfile
+        end
+      end
     end
   end
 end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -278,4 +278,8 @@ module FormMethods
   def deselect_representative_email
     uncheck REPRESENTATIVE_EMAIL
   end
+
+  def block_pdf_generation
+    Claim.last.remove_pdf!
+  end
 end

--- a/spec/support/pdf_methods.rb
+++ b/spec/support/pdf_methods.rb
@@ -2,7 +2,7 @@ module PdfMethods
   def pdf_to_hash(content)
     pdftk = PdfForms.new('pdftk')
 
-    pdf = Tempfile.new('generated_pdf')
+    pdf = Tempfile.new('generated_pdf', encoding: 'ascii-8bit')
     begin
       pdf.write(content)
       pdf.close


### PR DESCRIPTION
- [x] Background pdf (generate_pdf! can be called on a claim in any background process)
- [x] Adds a meta refresh page(5 seconds) for use when pdf has yet to be generated
- [x] Associate a pdf with a claim model
- [x] Carrierwave config. Expiry URL AWS setting needs tetsing!

![screen shot 2014-12-04 at 14 43 44](https://cloud.githubusercontent.com/assets/1006365/5300083/d3e9b502-7bc4-11e4-9841-4c9b1531f0ae.png)
