### PR TITLE
Claim#attachments S3 compat fix

### DIFF
--- a/app/services/jadu/claim.rb
+++ b/app/services/jadu/claim.rb
@@ -37,7 +37,7 @@ module Jadu
 
     def attachments
       @attachments ||= claim.attachments.reduce({}) do |o, a|
-        o.update File.basename(a.url) => a.file.read
+        o.update a.filename => a.file.read
       end
     end
 


### PR DESCRIPTION
Because:

``` ruby
File.basename 'http://example.com/lol/files/doc.rtf?token=such'
# => 'doc.rtf?token=such'
```
