### PR TITLE
Purge Secondary Claimants

### DIFF
--- a/app/forms/additional_claimants_form.rb
+++ b/app/forms/additional_claimants_form.rb
@@ -1,7 +1,10 @@
 class AdditionalClaimantsForm < Form
   boolean :has_additional_claimants
 
+  delegate :delete_additional_claimants_csv!, to: :target
+
   before_validation :reset_additional_claimants!, unless: :has_additional_claimants
+  before_save :delete_additional_claimants_csv!
 
   def has_additional_claimants
     if defined? @has_additional_claimants

--- a/app/forms/additional_claimants_upload_form.rb
+++ b/app/forms/additional_claimants_upload_form.rb
@@ -6,9 +6,11 @@ class AdditionalClaimantsUploadForm < Form
 
   delegate :additional_claimants_csv_cache, :additional_claimants_csv_cache=,
     :additional_claimants_csv_record_count=, :remove_additional_claimants_csv!,
-    :additional_claimants_csv_file, :reset_additional_claimants_count!, to: :target
+    :additional_claimants_csv_file, :delete_additional_claimants_csv!,
+    :secondary_claimants, to: :target
 
-  before_validation :remove_csv!, unless: :has_additional_claimants
+  before_validation :delete_additional_claimants_csv!, unless: :has_additional_claimants
+  before_save :delete_secondary_claimants!
 
   with_options if: :has_additional_claimants do |form|
     form.validates :additional_claimants_csv, presence: true
@@ -46,10 +48,7 @@ class AdditionalClaimantsUploadForm < Form
     errors.empty?
   end
 
-  def remove_csv!
-    if has_additional_claimants_csv?
-      remove_additional_claimants_csv!
-      reset_additional_claimants_count!
-    end
+  def delete_secondary_claimants!
+    secondary_claimants.clear
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -63,7 +63,8 @@ class Claim < ActiveRecord::Base
     claimants.count + additional_claimants_csv_record_count
   end
 
-  def reset_additional_claimants_count!
+  def delete_additional_claimants_csv!
+    remove_additional_claimants_csv!
     update_attribute(:additional_claimants_csv_record_count, 0)
   end
 

--- a/spec/forms/additional_claimants_form_spec.rb
+++ b/spec/forms/additional_claimants_form_spec.rb
@@ -113,5 +113,11 @@ RSpec.describe AdditionalClaimantsForm, :type => :form do
         expect(subject.save).to be false
       end
     end
+
+    it 'removes the additional claimants csv from the claim' do
+      expect(claim).to receive(:delete_additional_claimants_csv!)
+
+      subject.save
+    end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -109,14 +109,21 @@ RSpec.describe Claim, :type => :claim do
     end
   end
 
-  describe "#reset_additional_claimants_count!" do
+  describe "#delete_additional_claimants_csv!" do
     it "resets the additional cliamants count for csv's back to zero" do
       subject.additional_claimants_csv_record_count = 1
 
-      expect { subject.reset_additional_claimants_count! }.
+      expect { subject.delete_additional_claimants_csv! }.
         to change { subject.additional_claimants_csv_record_count }.
-        from(1).
-        to(0)
+        from(1).to(0)
+    end
+
+    it "removes the csv" do
+      subject.additional_claimants_csv = Tempfile.new('claimants.csv')
+
+      expect { subject.delete_additional_claimants_csv! }.
+        to change { subject.additional_claimants_csv.present? }.
+        from(true).to(false)
     end
   end
 


### PR DESCRIPTION
Purges secondary claimants if csv upload is used, similarly purges csv & record count if secondary claimants are added manually.

Fixes #415 
