### PR TITLE
Generate the PDF before we submit claim and email jobs.

### DIFF
--- a/app/controllers/claim_reviews_controller.rb
+++ b/app/controllers/claim_reviews_controller.rb
@@ -3,6 +3,7 @@ class ClaimReviewsController < ApplicationController
   before_action :check_session_expiry
 
   def update
+    claim.generate_pdf!
     claim.submit!
     attempt_send_confirmation_email
     redirect_to claim.payment_required? ? claim_payment_path : claim_confirmation_path

--- a/app/jobs/claim_submission_job.rb
+++ b/app/jobs/claim_submission_job.rb
@@ -2,7 +2,6 @@ class ClaimSubmissionJob < ActiveJob::Base
   queue_as :claim_submission
 
   def perform(claim)
-    claim.generate_pdf!
     Jadu::Claim.create claim
   end
 end

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -8,7 +8,6 @@ class BaseMailer < ActionMailer::Base
   end
 
   def confirmation_email(claim, email_addresses)
-    claim.generate_pdf!
     attachments[claim.pdf_filename] = claim.pdf_file.read
     @presenter = ConfirmationEmailPresenter.new(claim)
 


### PR DESCRIPTION
This seems to fix the submission error we saw the other day. I guess these jobs are generating the PDF at the same time and leaving it unreadable when the submission runs...
