### PR TITLE
Use correct filename when sending to Jadu

### DIFF
--- a/app/presenters/jadu_xml/file_presenter.rb
+++ b/app/presenters/jadu_xml/file_presenter.rb
@@ -4,7 +4,7 @@ module JaduXml
     property :checksum, as: "Checksum", exec_context: :decorator
 
     def filename
-      File.basename(represented.to_s)
+      File.basename(represented.filename)
     end
 
     def checksum


### PR DESCRIPTION
@dan-palmer think this was the fix so that the correct filename gets into the XML. Not sure if you want to fix the problem with the underscores too or wait to hear back from Jadu.
