### PR TITLE
Eval employment factories dates at runtime

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -126,9 +126,9 @@ FactoryGirl.define do
     enrolled_in_pension_scheme           true
     found_new_job                        false
     worked_notice_period_or_paid_in_lieu false
-    end_date                             3.weeks.ago
-    new_job_start_date                   3.days.ago
-    start_date                           10.years.ago
+    end_date                             { 3.weeks.ago }
+    new_job_start_date                   { 3.days.ago }
+    start_date                           { 10.years.ago }
     gross_pay                            4000
     net_pay                              3000
     new_job_gross_pay                    4000

--- a/spec/features/xml_generation_spec.rb
+++ b/spec/features/xml_generation_spec.rb
@@ -57,7 +57,7 @@ feature 'XML Generation', type: :feature do
         to match_array %w<file.csv file.rtf et1_barrington_wrigglesworth.pdf>
 
       expect(doc.xpath("//Checksum").children.map(&:to_s)).
-        to match_array %w<ee7d09ca06cab35f40f4a6b6d76704a7 58d5af93e8ee5b89e93eb13b750f8301 1d6c803f59b049b1acfc3a36b51562a3>
+        to match_array %w<ee7d09ca06cab35f40f4a6b6d76704a7 58d5af93e8ee5b89e93eb13b750f8301 29a4b89896139f349267a7130fa39e65>
     end
   end
 end


### PR DESCRIPTION
Employment dates are eval’d on `factories.rb` load so the dates are stubbed in tests. This fix evals the dates at runtime.
