### PR TITLE
Rst 3749 validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ gem 'uk_postcode', '~> 2.1'
 gem 'email_validator', '~> 1.6'
 gem 'typhoeus', '~> 1.4'
 gem 'invisible_captcha', '~> 2.0'
-gem 'et_gds_design_system', git:'https://github.com/hmcts/et_gds_design_system.git', tag: 'v3.0.0'
+gem 'et_gds_design_system', git:'https://github.com/hmcts/et_gds_design_system.git', tag: 'v3.0.3'
 
 gem "webpacker", "~> 5.4"
 gem "devise", "~> 4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/hmcts/et_gds_design_system.git
-  revision: a136d86f54d34365de384adeeea4074ddec63ddc
-  tag: v3.0.0
+  revision: 6da7539d61d30d1a1afc849358a4070af4e5dbbc
+  tag: v3.0.3
   specs:
-    et_gds_design_system (3.0.0)
+    et_gds_design_system (3.0.3)
       govuk_design_system_formbuilder (~> 2.1)
       rails (>= 6.0)
       webpacker (~> 5.0)
@@ -267,7 +267,7 @@ GEM
       roda (~> 3.48)
       thor (~> 1.1)
       tilt (~> 2.0, >= 2.0.10)
-    govuk_design_system_formbuilder (2.7.4)
+    govuk_design_system_formbuilder (2.7.5)
       actionview (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)

--- a/app/forms/refunds/fees_form.rb
+++ b/app/forms/refunds/fees_form.rb
@@ -37,7 +37,7 @@ module Refunds
 
     validates :et_issue_fee_payment_date,
       presence: true,
-      date: true,
+      date: { omit_day: true },
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: -> { et_issue_fee.try(:positive?) && !et_issue_fee_payment_date_unknown? }
 
@@ -48,7 +48,7 @@ module Refunds
 
     validates :et_hearing_fee_payment_date,
       presence: true,
-      date: true,
+      date: { omit_day: true },
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: -> { et_hearing_fee.try(:positive?) && !et_hearing_fee_payment_date_unknown? }
 
@@ -59,7 +59,7 @@ module Refunds
 
     validates :et_reconsideration_fee_payment_date,
       presence: true,
-      date: true,
+      date: { omit_day: true },
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: -> { et_reconsideration_fee.try(:positive?) && !et_reconsideration_fee_payment_date_unknown? }
 
@@ -70,7 +70,7 @@ module Refunds
 
     validates :eat_issue_fee_payment_date,
       presence: true,
-      date: true,
+      date: { omit_day: true },
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: -> { eat_issue_fee.try(:positive?) && !eat_issue_fee_payment_date_unknown? }
 
@@ -81,7 +81,7 @@ module Refunds
 
     validates :eat_hearing_fee_payment_date,
       presence: true,
-      date: true,
+      date: { omit_day: true },
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: -> { eat_hearing_fee.try(:positive?) && !eat_hearing_fee_payment_date_unknown? }
 

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,15 +1,24 @@
 # @TODO This class can be much simpler once we are not worrying about values being hashes,
 # strings etc.. (once all forms are converted to NullDbForm)
 class DateValidator < ActiveModel::EachValidator
+  def initialize(omit_day: false, **kwargs)
+    @omit_day = omit_day
+    super(**kwargs)
+  end
+
   def validate_each(record, attribute, value)
-    if illegal_year?(value)
+    if illegal_date?(record, attribute)
+      record.errors.add(attribute, :invalid)
+    elsif illegal_year?(value)
       record.errors.add(attribute, :invalid)
     elsif coercion_failed?(value, attribute, record) || non_empty_string?(value, attribute, record)
-      record.errors.add(attribute)
+      record.errors.add(attribute, :invalid)
     end
   end
 
   private
+
+  attr_reader :omit_day
 
   # @TODO This will not need to check for a hash once all forms are converted to the NullDbForm
   def coercion_failed?(value, attribute, record)
@@ -35,10 +44,33 @@ class DateValidator < ActiveModel::EachValidator
     elsif value.is_a?(Date) || value.is_a?(Time)
       value.year < 1000
     else
-      value[:year].present? && value[:year].to_i < 1000
+      value[1].present? && value[1].to_i < 1000
     end
   rescue ArgumentError
     false
+  end
+
+  def illegal_date?(record, attribute)
+    # The date type in rails seems a bit basic in terms of validation - it will accept 31/2/xxxx but not 32/2/xxxx,
+    #   neither of which should be valid so we are going to validate better here.
+    value = read_attribute_before_type_cast(record, attribute, default: nil)
+    if value.is_a?(Hash) && value.values.all?(&:present?)
+      Date.new(value[1], value[2], value[3] || (omit_day ? 1 : null))
+      false
+    elsif value.is_a?(String) && value.blank?
+      false
+    elsif value.is_a?(String)
+      Date.parse(value)
+      false
+    elsif value.is_a?(Date) || value.is_a?(Time)
+      false
+    elsif value.nil?
+      false
+    else
+      true
+    end
+  rescue Date::Error, TypeError
+    true
   end
 
   def read_attribute_before_type_cast(record, attribute, default:)

--- a/spec/forms/employment_form_spec.rb
+++ b/spec/forms/employment_form_spec.rb
@@ -12,26 +12,26 @@ RSpec.describe EmploymentForm, type: :form do
   describe 'validations' do
     shared_examples 'common date examples' do |field:|
       it 'rejects a 2 digit year' do
-        employment_form.send(:"#{field}=", {day: '1', month: '1', year: '16'})
+        employment_form.attributes={"#{field}(3i)" => '1', "#{field}(2i)" => '1', "#{field}(1i)" => '16'}
         employment_form.valid?
         expect(employment_form.errors.details[field]).to include(a_hash_including error: :invalid)
 
       end
 
       it 'rejects a missing year' do
-        employment_form.send(:"#{field}=", {day: '1', month: '1', year: ''})
+        employment_form.attributes={"#{field}(3i)" => '1', "#{field}(2i)" => '1', "#{field}(1i)" => ''}
         employment_form.valid?
         expect(employment_form.errors.details[field]).to include(a_hash_including error: :invalid)
       end
 
       it 'rejects a missing month' do
-        employment_form.send(:"#{field}=", {day: '1', month: '', year: '2010'})
+        employment_form.attributes={"#{field}(3i)" => '1', "#{field}(2i)" => '', "#{field}(1i)" => '2010'}
         employment_form.valid?
         expect(employment_form.errors.details[field]).to include(a_hash_including error: :invalid)
       end
 
       it 'rejects a missing day' do
-        employment_form.send(:"#{field}=", {day: '', month: '1', year: '2010'})
+        employment_form.attributes={"#{field}(3i)" => '', "#{field}(2i)" => '1', "#{field}(1i)" => '2010'}
         employment_form.valid?
         expect(employment_form.errors.details[field]).to include(a_hash_including error: :invalid)
       end

--- a/spec/forms/refunds/applicant_form_spec.rb
+++ b/spec/forms/refunds/applicant_form_spec.rb
@@ -119,7 +119,6 @@ module Refunds
                     'applicant_date_of_birth(1i)' => '1985' }
           applicant_form.assign_attributes(value)
 
-          applicant_form.applicant_date_of_birth = { 3 => '1', 2 => '3', 1 => '1980' }
           applicant_form.valid?
           expect(applicant_form.errors).not_to include :applicant_date_of_birth
         end

--- a/spec/forms/refunds/fees_form_spec.rb
+++ b/spec/forms/refunds/fees_form_spec.rb
@@ -8,7 +8,7 @@ module Refunds
     it_behaves_like 'a Form', {
       et_issue_fee: '12',
       et_issue_fee_payment_method: 'card',
-      et_issue_fee_payment_date: { 3 => '1', 2 => '1', 1 => '2016' }
+      et_issue_fee_payment_date: { 3 => 1, 2 => 1, 1 => 2016 }
     }, Session
 
     describe 'validation' do
@@ -248,7 +248,7 @@ module Refunds
         end
 
         it 'converts a full date from a hash' do
-          form.send(writer_method, 2 => '12', 1 => '2016', 3 => '12')
+          form.send(writer_method, 2 => 12, 1 => 2016, 3 => 12)
           expect(form.send(reader_method)).to eql Date.parse('12 December 2016')
         end
 
@@ -258,8 +258,8 @@ module Refunds
         end
 
         it 'leaves an invalid date from a hash as is' do
-          form.send(writer_method, 2 => '13', 1 => '2016')
-          expect(form.send(reader_method)).to eql(1 => '2016', 2 => '13'), "Expected invalid month to have converted to nil for '#{writer_method}'"
+          form.send(writer_method, 2 => 13, 1 => 2016)
+          expect(form.send(:"#{reader_method}_before_type_cast")).to eql(1 => 2016, 2 => 13), "Expected invalid month to have converted to nil for '#{writer_method}'"
         end
 
         it 'converts a partial date from an action controller params instance' do
@@ -288,7 +288,7 @@ module Refunds
           value = ActionController::Parameters.new("#{reader_method}(2i)" => '13',
                                                    "#{reader_method}(1i)" => '2016').permit!
           form.assign_attributes(value)
-          expect(form.send(reader_method)).to eql 2 => 13, 1 => 2016
+          expect(form.send(:"#{reader_method}_before_type_cast")).to eql 2 => 13, 1 => 2016
         end
 
         it 'does not convert nil' do

--- a/spec/support/refunds_steps/applicant_steps.rb
+++ b/spec/support/refunds_steps/applicant_steps.rb
@@ -80,7 +80,7 @@ def and_the_email_address_in_the_refund_applicant_page_should_be_marked_with_an_
 end
 
 def and_the_date_of_birth_in_the_refund_applicant_page_should_be_marked_with_an_invalid_error
-  expect(refund_applicant_page.about_the_claimant.date_of_birth_question.error.text).to eql 'is invalid'
+  expect(refund_applicant_page.about_the_claimant.date_of_birth_question.error.text).to eql 'Enter your date of birth'
 end
 
 def then_the_title_field_in_the_applicant_page_should_have_the_correct_default_option_selected

--- a/spec/types/et_date_spec.rb
+++ b/spec/types/et_date_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe EtDateType do
+  class ExampleForm < ActiveRecord::Base
+    establish_connection adapter: :nulldb,
+                         schema: 'config/nulldb_schema.rb'
+    attribute :date, :et_date
+  end
+
+  let(:form) { ExampleForm.new }
+
+  describe 'multi parameter assignment' do
+    it 'converts valid value' do
+      form.attributes = {
+        'date(1i)' => '2000',
+        'date(2i)' => '2',
+        'date(3i)' => '28'
+      }
+      expect(form.date).to eql(Date.parse('2000-02-28'))
+    end
+
+    it 'does not convert an invalid value - 30th february' do
+      form.attributes = {
+        'date(1i)' => '2000',
+        'date(2i)' => '2',
+        'date(3i)' => '30'
+      }
+      expect(form.date).to be_nil
+    end
+
+    it 'retains the invalid value - 30th february' do
+      form.attributes = {
+        'date(1i)' => '2000',
+        'date(2i)' => '2',
+        'date(3i)' => '30'
+      }
+      expect(form.read_attribute_before_type_cast(:date)).to eql 1 => 2000, 2 => 2, 3 => 30
+    end
+
+    it 'does not convert an invalid value - non numeric month' do
+      form.attributes = {
+        'date(1i)' => '2000',
+        'date(2i)' => 'feb',
+        'date(3i)' => '30'
+      }
+      expect(form.date).to be_nil
+    end
+
+    it 'retains the invalid value - 30th february - has zero value' do
+      form.attributes = {
+        'date(1i)' => '2000',
+        'date(2i)' => 'feb',
+        'date(3i)' => '30'
+      }
+      expect(form.read_attribute_before_type_cast(:date)).to eql 1 => 2000, 2 => 0, 3 => 30
+    end
+  end
+
+  context 'configured with allow_2_digit_year' do
+    class FormWith2Digit < ActiveRecord::Base
+      establish_connection adapter: :nulldb,
+                           schema: 'config/nulldb_schema.rb'
+      attribute :date, :et_date, allow_2_digit_year: true
+    end
+    let(:form) { FormWith2Digit.new }
+    describe 'multi parameter assignment' do
+      it 'converts valid value' do
+        form.attributes = {
+          'date(1i)' => '70',
+          'date(2i)' => '2',
+          'date(3i)' => '28'
+        }
+        expect(form.date).to eql(Date.parse('1970-02-28'))
+      end
+
+      it 'does not convert an invalid value' do
+        form.attributes = {
+          'date(1i)' => '70',
+          'date(2i)' => '2',
+          'date(3i)' => '30'
+        }
+        expect(form.date).to be_nil
+      end
+
+      it 'retains the invalid value' do
+        form.attributes = {
+          'date(1i)' => '70',
+          'date(2i)' => '2',
+          'date(3i)' => '30'
+        }
+        expect(form.read_attribute_before_type_cast(:date)).to eql 1 => 70, 2 => 2, 3 => 30
+      end
+    end
+
+
+  end
+  context 'configured with omit_day' do
+    class FormWithOmitDay < ActiveRecord::Base
+      establish_connection adapter: :nulldb,
+                           schema: 'config/nulldb_schema.rb'
+      attribute :date, :et_date, omit_day: true
+    end
+    let(:form) { FormWithOmitDay.new }
+    describe 'multi parameter assignment' do
+      it 'converts valid value' do
+        form.attributes = {
+          'date(1i)' => '2000',
+          'date(2i)' => '2'
+        }
+        expect(form.date).to eql(Date.parse('2000-02-01'))
+      end
+
+      it 'does not convert an invalid value' do
+        form.attributes = {
+          'date(1i)' => '2000',
+          'date(2i)' => '13'
+        }
+        expect(form.date).to be_nil
+      end
+
+      it 'retains the invalid value' do
+        form.attributes = {
+          'date(1i)' => '2000',
+          'date(2i)' => '13'
+        }
+        expect(form.read_attribute_before_type_cast(:date)).to eql 1 => 2000, 2 => 13
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

This PR fixes many issues with dates in the system.

Historically, ET1 invented its own way of dealing with dates and it used a hash to represent the date.

The new GDS gem expects dates to be represented in the normal way (a hash with numeric keys 1 = year, 2 = month, 3 = day)

Whilst this was already done, the validation of dates was not good enough - this is true for rails date validations in general - as they dont handle things like '30th february' (the date would get rounded to 2nd march and then pass validation)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
