### PR TITLE
RST-3742 Disabled turbolinks on the skip to main content link

### DIFF
--- a/app/views/layouts/moj_template.html.erb
+++ b/app/views/layouts/moj_template.html.erb
@@ -37,7 +37,7 @@
 
 </script>
 
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+<a href="#main-content" class="govuk-skip-link" data-turbolinks="false">Skip to main content</a>
 
 <div id="cookie-banner">
   <div class="outer-block">


### PR DESCRIPTION

### JIRA link (if applicable) ###

RST-3742

### Change description ###

Disables turbolinks on skip to main content link - this was causing the page to reload when it was clicked even though it is just an anchor within the page

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
